### PR TITLE
wip: new adapter implementation with better-call runtime

### DIFF
--- a/packages/experimental/README.md
+++ b/packages/experimental/README.md
@@ -91,7 +91,7 @@ const createSession = v.fn(
 );
 ```
 
-There are also accumulating vars (`v.record`), computed vars (`v.derive`), reshaping (`customize`), and mountable widening (`v.extend`).
+There are also accumulating vars (`v.merge`), computed vars (`v.derive`), reshaping (`customize`), and mountable widening (`v.extend`).
 
 ### modules
 

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -56,17 +56,6 @@
 				"default": "./dist/index.cjs"
 			}
 		},
-		"./client": {
-			"dev-source": "./src/client.ts",
-			"import": {
-				"types": "./dist/client.d.mts",
-				"default": "./dist/client.mjs"
-			},
-			"require": {
-				"types": "./dist/client.d.cts",
-				"default": "./dist/client.cjs"
-			}
-		},
 		"./error": {
 			"dev-source": "./src/error.ts",
 			"import": {
@@ -76,17 +65,6 @@
 			"require": {
 				"types": "./dist/error.d.cts",
 				"default": "./dist/error.cjs"
-			}
-		},
-		"./node": {
-			"dev-source": "./src/adapters/node/index.ts",
-			"import": {
-				"types": "./dist/node.d.mts",
-				"default": "./dist/node.mjs"
-			},
-			"require": {
-				"types": "./dist/node.d.cts",
-				"default": "./dist/node.cjs"
 			}
 		}
 	},

--- a/packages/experimental/src/fn.ts
+++ b/packages/experimental/src/fn.ts
@@ -23,7 +23,13 @@ import {
 	validate,
 	vTypes,
 } from "./schema";
-import type { HandleScope, ResolvedVars, ScopeOf, VarName } from "./scope";
+import type {
+	HandleScope,
+	ResolvedVars,
+	ScopeOf,
+	VarName,
+	VarSetVal,
+} from "./scope";
 import type { LiteralString, Prettify } from "./types";
 import {
 	type Cells,
@@ -761,7 +767,7 @@ export interface InstanceOn<Base, BaseFns, Prefix extends string> {
 		handler: (
 			c: VarSetContext<VarNameOfT<T>> & {
 				value: VarNameOfT<T> extends keyof ScopeOf<[], Base>
-					? ScopeOf<[], Base>[VarNameOfT<T>]
+					? VarSetVal<ScopeOf<[], Base>[VarNameOfT<T>]>
 					: unknown;
 			},
 			next: () => void,

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -2,6 +2,7 @@ import { type Fn, fnImpl } from "./fn";
 import { extendVar, on } from "./module";
 
 import { type InferArgs, type InferInput, vTypes } from "./schema";
+import type { VarSlot } from "./scope";
 import type { LiteralString } from "./types";
 import {
 	deriveVar,
@@ -14,14 +15,19 @@ import {
 interface V {
 	fn: Fn;
 	/**
-	 * Schema vars use `InferArgs` as their handle type so `.set()` accepts
-	 * the same partial shape callers send as input (optional / defaulted
-	 * fields may be omitted). Fn input still validates to `InferInput`.
+	 * Schema vars store `InferInput` (what `.get()` returns after
+	 * validation/defaults/transforms) and accept `InferArgs` on `.set()`
+	 * (optional / defaulted fields may be omitted). Fn input still
+	 * validates to `InferInput`.
 	 */
 	var: <N extends LiteralString, S = undefined, D = undefined>(
 		name: N,
 		options?: { default?: D; schema?: S },
-	) => VarDefination<N, [S] extends [undefined] ? D : InferArgs<S> | D, S>;
+	) => VarDefination<
+		N,
+		[S] extends [undefined] ? D : VarSlot<InferInput<S> | D, InferArgs<S> | D>,
+		S
+	>;
 	/** A var you accumulate into: `set()` merges instead of replacing. */
 	merge: <N extends LiteralString, S = undefined>(
 		name: N,
@@ -110,9 +116,12 @@ export type {
 	HandleScope,
 	ResolvedVars,
 	ScopeOf,
+	VarGet,
 	VarHandle,
 	VarName,
 	VarScope,
+	VarSetVal,
+	VarSlot,
 } from "./scope";
 export type { LiteralString, Prettify } from "./types";
 export type { VarCustomizer, VarDefination, VarMap } from "./var";

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -1,7 +1,7 @@
 import { type Fn, fnImpl } from "./fn";
 import { extendVar, on } from "./module";
 
-import { type InferInput, vTypes } from "./schema";
+import { type InferArgs, type InferInput, vTypes } from "./schema";
 import type { LiteralString } from "./types";
 import {
 	deriveVar,
@@ -13,12 +13,17 @@ import {
 
 interface V {
 	fn: Fn;
+	/**
+	 * Schema vars use `InferArgs` as their handle type so `.set()` accepts
+	 * the same partial shape callers send as input (optional / defaulted
+	 * fields may be omitted). Fn input still validates to `InferInput`.
+	 */
 	var: <N extends LiteralString, S = undefined, D = undefined>(
 		name: N,
 		options?: { default?: D; schema?: S },
-	) => VarDefination<N, [S] extends [undefined] ? D : InferInput<S> | D, S>;
+	) => VarDefination<N, [S] extends [undefined] ? D : InferArgs<S> | D, S>;
 	/** A var you accumulate into: `set()` merges instead of replacing. */
-	record: <N extends LiteralString, S = undefined>(
+	merge: <N extends LiteralString, S = undefined>(
 		name: N,
 		options?: { schema?: S },
 	) => VarDefination<
@@ -50,14 +55,17 @@ interface V {
 	number: (typeof vTypes)["number"];
 	boolean: (typeof vTypes)["boolean"];
 	object: (typeof vTypes)["object"];
+	array: (typeof vTypes)["array"];
+	record: (typeof vTypes)["record"];
+	enum: (typeof vTypes)["enum"];
 	any: (typeof vTypes)["any"];
 }
 
 export const v: V = {
 	fn: fnImpl as Fn,
 	var: makeVar as V["var"],
-	record: ((name: string, options: any = {}) =>
-		makeVar(name, { ...options, accessor: true })) as V["record"],
+	merge: ((name: string, options: any = {}) =>
+		makeVar(name, { ...options, accessor: true })) as V["merge"],
 	derive: deriveVar as V["derive"],
 	on,
 	extend: extendVar,

--- a/packages/experimental/src/schema.test.ts
+++ b/packages/experimental/src/schema.test.ts
@@ -163,6 +163,18 @@ describe("v.record", () => {
 		expect(validate(anyRec, { a: 1, b: "x" }, "r")).toEqual({ a: 1, b: "x" });
 	});
 
+	it("keeps __proto__ as an own data key", () => {
+		const poisoned = JSON.parse('{"__proto__":1,"a":2}');
+		const parsed = validate(scores, poisoned, "scores") as Record<
+			string,
+			number
+		>;
+		expect(Object.hasOwn(parsed, "__proto__")).toBe(true);
+		expect(parsed.__proto__).toBe(1);
+		expect(parsed.a).toBe(2);
+		expect(Object.getPrototypeOf(parsed)).toBeNull();
+	});
+
 	it("works as a fn input field", () => {
 		const f = v.fn(
 			{ input: { tags: v.record(v.string()) } },

--- a/packages/experimental/src/schema.test.ts
+++ b/packages/experimental/src/schema.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { ValidationError, v } from "./index";
+import type { InferArgs, InferInput } from "./schema";
+import { validate } from "./schema";
+
+describe("v.enum", () => {
+	const role = v.enum(["admin", "user"]);
+
+	it("narrows to the literal union", () => {
+		expectTypeOf<InferInput<typeof role>>().toEqualTypeOf<"admin" | "user">();
+		expectTypeOf<InferArgs<typeof role>>().toEqualTypeOf<"admin" | "user">();
+	});
+
+	it("accepts listed values", () => {
+		expect(validate(role, "admin", "role")).toBe("admin");
+		expect(validate(role, "user", "role")).toBe("user");
+	});
+
+	it("rejects values outside the set", () => {
+		expect(() => validate(role, "guest", "role")).toThrow(ValidationError);
+		expect(() => validate(role, "guest", "role")).toThrow(/one of/);
+	});
+
+	it("works as a fn input field", () => {
+		const f = v.fn({ input: { role } }, (c) => c.input.role);
+		expect(f({ role: "admin" })).toBe("admin");
+		expect(() => f({ role: "guest" } as never)).toThrow(ValidationError);
+		expectTypeOf(f).returns.toEqualTypeOf<"admin" | "user">();
+	});
+
+	it("supports number and boolean literals", () => {
+		const status = v.enum([200, 404] as const);
+		const flag = v.enum([true, false] as const);
+		expect(validate(status, 200, "s")).toBe(200);
+		expect(() => validate(status, 500, "s")).toThrow(ValidationError);
+		expect(validate(flag, false, "f")).toBe(false);
+	});
+});
+
+describe("v.array", () => {
+	const tags = v.array(v.string({ min: 1 }));
+
+	it("infers an array of the item type", () => {
+		expectTypeOf<InferInput<typeof tags>>().toEqualTypeOf<string[]>();
+		expectTypeOf<InferArgs<typeof tags>>().toEqualTypeOf<string[]>();
+	});
+
+	it("validates every element", () => {
+		expect(validate(tags, ["a", "b"], "tags")).toEqual(["a", "b"]);
+		expect(() => validate(tags, ["a", ""], "tags")).toThrow(ValidationError);
+		expect(() => validate(tags, ["a", ""], "tags")).toThrow(/tags\[1\]/);
+	});
+
+	it("rejects non-arrays", () => {
+		expect(() => validate(tags, "nope", "tags")).toThrow(/expected array/);
+	});
+
+	it("enforces length rules", () => {
+		const pair = v.array(v.number(), { length: 2 });
+		expect(validate(pair, [1, 2], "p")).toEqual([1, 2]);
+		expect(() => validate(pair, [1], "p")).toThrow(/expected length 2/);
+
+		const few = v.array(v.number(), { min: 1, max: 2 });
+		expect(() => validate(few, [], "f")).toThrow(/at least 1/);
+		expect(() => validate(few, [1, 2, 3], "f")).toThrow(/at most 2/);
+	});
+
+	it("collects every bad element", () => {
+		try {
+			validate(tags, ["", ""], "tags");
+			expect.unreachable();
+		} catch (e) {
+			expect(e).toBeInstanceOf(ValidationError);
+			expect((e as ValidationError).issues).toHaveLength(2);
+		}
+	});
+
+	it("with no item schema, any array passes", () => {
+		const anyArr = v.array();
+		expect(validate(anyArr, [1, "x", null], "a")).toEqual([1, "x", null]);
+	});
+
+	it("nests objects and keeps optional/default args", () => {
+		const rows = v.array(
+			v.object({
+				id: v.string(),
+				n: v.number({ default: 0 }),
+			}),
+		);
+		expectTypeOf<InferArgs<typeof rows>>().toEqualTypeOf<
+			{ id: string; n?: number }[]
+		>();
+		expectTypeOf<InferInput<typeof rows>>().toEqualTypeOf<
+			{ id: string; n: number }[]
+		>();
+		expect(validate(rows, [{ id: "1" }], "rows")).toEqual([{ id: "1", n: 0 }]);
+	});
+
+	it("works as a fn input field", () => {
+		const f = v.fn({ input: { ids: v.array(v.string()) } }, (c) => c.input.ids);
+		expect(f({ ids: ["a", "b"] })).toEqual(["a", "b"]);
+		expect(() => f({ ids: [1] } as never)).toThrow(ValidationError);
+	});
+});
+
+describe("v.record", () => {
+	const scores = v.record(v.number({ min: 0 }));
+
+	it("infers Record<string, value>", () => {
+		expectTypeOf<InferInput<typeof scores>>().toEqualTypeOf<
+			Record<string, number>
+		>();
+		expectTypeOf<InferArgs<typeof scores>>().toEqualTypeOf<
+			Record<string, number>
+		>();
+	});
+
+	it("validates every value", () => {
+		expect(validate(scores, { a: 1, b: 2 }, "scores")).toEqual({
+			a: 1,
+			b: 2,
+		});
+		expect(() => validate(scores, { a: -1 }, "scores")).toThrow(
+			ValidationError,
+		);
+		expect(() => validate(scores, { a: -1 }, "scores")).toThrow(/scores\.a/);
+	});
+
+	it("rejects non-objects", () => {
+		expect(() => validate(scores, "nope", "scores")).toThrow(/expected object/);
+	});
+
+	it("collects every bad entry", () => {
+		try {
+			validate(scores, { a: -1, b: -2 }, "scores");
+			expect.unreachable();
+		} catch (e) {
+			expect(e).toBeInstanceOf(ValidationError);
+			expect((e as ValidationError).issues).toHaveLength(2);
+		}
+	});
+
+	it("applies defaults inside each value", () => {
+		const fields = v.record(
+			v.object({
+				type: v.string({ default: "string" }),
+				unique: v.boolean({ optional: true, default: false }),
+			}),
+		);
+		expectTypeOf<InferArgs<typeof fields>>().toEqualTypeOf<
+			Record<string, { type?: string; unique?: boolean }>
+		>();
+		expectTypeOf<InferInput<typeof fields>>().toEqualTypeOf<
+			Record<string, { type: string; unique: boolean }>
+		>();
+		expect(validate(fields, { id: {} }, "fields")).toEqual({
+			id: { type: "string", unique: false },
+		});
+	});
+
+	it("with no value schema, any object passes", () => {
+		const anyRec = v.record();
+		expect(validate(anyRec, { a: 1, b: "x" }, "r")).toEqual({ a: 1, b: "x" });
+	});
+
+	it("works as a fn input field", () => {
+		const f = v.fn(
+			{ input: { tags: v.record(v.string()) } },
+			(c) => c.input.tags,
+		);
+		expect(f({ tags: { a: "x" } })).toEqual({ a: "x" });
+		expect(() => f({ tags: { a: 1 } } as never)).toThrow(ValidationError);
+	});
+});

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -463,7 +463,9 @@ export const validate = (
 			return def.transform ? def.transform(value) : value;
 		}
 		const item = asType(def.shape);
-		const parsed: Record<string, unknown> = {};
+		// null-prototype so user keys like "__proto__" become own data
+		// properties instead of mutating Object.prototype.
+		const parsed: Record<string, unknown> = Object.create(null);
 		const issues: Issue[] = [];
 		for (const [key, child] of entries) {
 			try {

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -81,6 +81,19 @@ type NumberOptions<O> = TypeOptions<number, O> &
 		enum?: readonly number[];
 	};
 
+/** Array length constraints (same keys as string length). */
+type ArrayOptions<ItemOut, O> = TypeOptions<ItemOut[], O> &
+	Pick<Rules, "min" | "max" | "length" | "check">;
+
+/** Record entry-count constraints (same keys as array length). */
+type RecordOptions<ValueOut, O> = TypeOptions<Record<string, ValueOut>, O> &
+	Pick<Rules, "min" | "max" | "length" | "check">;
+
+type EnumValue = string | number | boolean;
+
+type EnumOptions<T extends EnumValue, O> = TypeOptions<T, O> &
+	Pick<Rules, "check">;
+
 export type InferType<T> =
 	T extends TypeDefination<infer T2, any, any> ? T2 : never;
 
@@ -370,6 +383,106 @@ export const validate = (
 		}
 		return def.transform ? def.transform(parsed) : parsed;
 	}
+	if (def.name === "array") {
+		if (!Array.isArray(value)) {
+			throw new ValidationError(
+				path,
+				`expected array, received ${typeOf(value)}`,
+			);
+		}
+		if (def.length !== undefined && value.length !== def.length) {
+			fail(path, `expected length ${def.length}, received ${value.length}`);
+		}
+		if (def.min !== undefined && value.length < def.min) {
+			fail(
+				path,
+				`expected at least ${def.min} items, received ${value.length}`,
+			);
+		}
+		if (def.max !== undefined && value.length > def.max) {
+			fail(path, `expected at most ${def.max} items, received ${value.length}`);
+		}
+		if (def.check) {
+			const result = def.check(value);
+			if (result !== true) {
+				fail(path, typeof result === "string" ? result : "failed check");
+			}
+		}
+		// No item schema (`v.array()`): ANY array - passed through as-is.
+		if (def.shape === undefined) {
+			return def.transform ? def.transform(value) : value;
+		}
+		const item = asType(def.shape);
+		const parsed: unknown[] = [];
+		const issues: Issue[] = [];
+		for (let i = 0; i < value.length; i++) {
+			try {
+				parsed.push(validate(item, value[i], `${path}[${i}]`));
+			} catch (thrown) {
+				if (!(thrown instanceof ValidationError)) throw thrown;
+				issues.push(...thrown.issues);
+			}
+		}
+		const firstIssue = issues[0];
+		if (firstIssue) {
+			throw new ValidationError(firstIssue.path, firstIssue.message, issues);
+		}
+		return def.transform ? def.transform(parsed) : parsed;
+	}
+	if (def.name === "record") {
+		if (typeOf(value) !== "object") {
+			throw new ValidationError(
+				path,
+				`expected object, received ${typeOf(value)}`,
+			);
+		}
+		const entries = Object.entries(value as Record<string, unknown>);
+		if (def.length !== undefined && entries.length !== def.length) {
+			fail(path, `expected length ${def.length}, received ${entries.length}`);
+		}
+		if (def.min !== undefined && entries.length < def.min) {
+			fail(
+				path,
+				`expected at least ${def.min} entries, received ${entries.length}`,
+			);
+		}
+		if (def.max !== undefined && entries.length > def.max) {
+			fail(
+				path,
+				`expected at most ${def.max} entries, received ${entries.length}`,
+			);
+		}
+		if (def.check) {
+			const result = def.check(value);
+			if (result !== true) {
+				fail(path, typeof result === "string" ? result : "failed check");
+			}
+		}
+		// No value schema (`v.record()`): ANY object - passed through as-is.
+		if (def.shape === undefined) {
+			return def.transform ? def.transform(value) : value;
+		}
+		const item = asType(def.shape);
+		const parsed: Record<string, unknown> = {};
+		const issues: Issue[] = [];
+		for (const [key, child] of entries) {
+			try {
+				parsed[key] = validate(item, child, `${path}.${key}`);
+			} catch (thrown) {
+				if (!(thrown instanceof ValidationError)) throw thrown;
+				issues.push(...thrown.issues);
+			}
+		}
+		const firstIssue = issues[0];
+		if (firstIssue) {
+			throw new ValidationError(firstIssue.path, firstIssue.message, issues);
+		}
+		return def.transform ? def.transform(parsed) : parsed;
+	}
+	if (def.name === "enum") {
+		applyRules(def, value, path);
+		return def.transform ? def.transform(value) : value;
+	}
 	if (typeOf(value) !== def.name) {
 		throw new ValidationError(
 			path,
@@ -423,4 +536,63 @@ export const vTypes = {
 		? TypeDefination<Record<string, any>, Record<string, any>>
 		: TypeDefination<ArgsShape<S>, OutOf<O, D, Opt>, DefOf<D, Opt>> =>
 		build("object", options, shape === undefined ? {} : { shape }),
+	/** With an ITEM every element validates; with NO item (`v.array()`)
+	 * any array passes, as-is. */
+	array: <
+		I = undefined,
+		O = [I] extends [undefined] ? unknown[] : InferInput<I>[],
+		D = never,
+		Opt extends boolean = false,
+	>(
+		item?: I,
+		options?: ArrayOptions<
+			[I] extends [undefined] ? unknown : InferInput<I>,
+			O
+		> &
+			WithDefault<D> &
+			WithOptional<Opt>,
+	): [I] extends [undefined]
+		? TypeDefination<unknown[], unknown[]>
+		: TypeDefination<InferArgs<I>[], OutOf<O, D, Opt>, DefOf<D, Opt>> =>
+		build("array", options, item === undefined ? {} : { shape: item }),
+	/**
+	 * Dynamic string keys → value schema (`Record<string, V>`). With a
+	 * VALUE every entry validates; with NO value (`v.record()`) any
+	 * object passes, as-is.
+	 */
+	record: <
+		V = undefined,
+		O = [V] extends [undefined]
+			? Record<string, unknown>
+			: Record<string, InferInput<V>>,
+		D = never,
+		Opt extends boolean = false,
+	>(
+		value?: V,
+		options?: RecordOptions<
+			[V] extends [undefined] ? unknown : InferInput<V>,
+			O
+		> &
+			WithDefault<D> &
+			WithOptional<Opt>,
+	): [V] extends [undefined]
+		? TypeDefination<Record<string, unknown>, Record<string, unknown>>
+		: TypeDefination<
+				Record<string, InferArgs<V>>,
+				OutOf<O, D, Opt>,
+				DefOf<D, Opt>
+			> =>
+		build("record", options, value === undefined ? {} : { shape: value }),
+	/** One of the listed literals. `const` on the tuple keeps the union
+	 * narrow: `v.enum(["a", "b"])` is `"a" | "b"`. */
+	enum: <
+		const T extends readonly EnumValue[],
+		O = T[number],
+		D = never,
+		Opt extends boolean = false,
+	>(
+		values: T,
+		options?: EnumOptions<T[number], O> & WithDefault<D> & WithOptional<Opt>,
+	): TypeDefination<T[number], OutOf<O, D, Opt>, DefOf<D, Opt>> =>
+		build("enum", options, { enum: values }),
 } satisfies Record<string, (...args: any[]) => TypeDefination<any, any>>;

--- a/packages/experimental/src/scope.ts
+++ b/packages/experimental/src/scope.ts
@@ -49,6 +49,9 @@ export type VarName<RV> = keyof RV & string;
  * mistaken for the value (`c.var.session.userId` is a type error; it is
  * `c.var.session.get().userId`). `set` is always synchronous, and absent
  * entirely on a readonly frame.
+ *
+ * For schema vars, `T` is the write/args shape (`InferArgs`) so defaulted
+ * or optional fields may be omitted in `.set(...)`.
  */
 export type VarHandle<T, RO extends boolean = false> = Prettify<
 	{ get(): T } & (RO extends true ? unknown : { set(value: T): void })

--- a/packages/experimental/src/scope.ts
+++ b/packages/experimental/src/scope.ts
@@ -1,14 +1,43 @@
-import type { ModuleVars, VarExtensionsFor } from "./module";
+import type {
+	ModuleVars,
+	VarExtensionArgsFor,
+	VarExtensionsFor,
+} from "./module";
 import type { Prettify } from "./types";
 import type { VarDefination } from "./var";
 
+declare const __varSet: unique symbol;
+
+/**
+ * Phantom wrapper pairing a stored/read shape (`Get`) with a write/args
+ * shape (`Set`). Only used in the type system - runtime values are plain.
+ */
+export type VarSlot<Get, Set = Get> = Get & {
+	readonly [__varSet]?: Set;
+};
+
+export type VarGet<V> = V extends VarSlot<infer G, any> ? G : V;
+export type VarSetVal<V> =
+	V extends VarSlot<any, infer S> ? ([unknown] extends [S] ? VarGet<V> : S) : V;
+
 export type VarValues<V> = {
 	[K in keyof V]: V[K] extends VarDefination<any, infer T, any, any>
-		? T
+		? VarGet<T>
 		: never;
 };
 
-type MergeExtension<T, E> = T extends object ? Prettify<T & E> : T;
+type MergeOnto<T, E> = [E] extends [never]
+	? T
+	: unknown extends E
+		? T
+		: T extends object
+			? Prettify<T & E>
+			: T;
+
+type MergeVarValue<T, GetE, SetE> =
+	T extends VarSlot<infer G, infer S>
+		? VarSlot<MergeOnto<G, GetE>, MergeOnto<S, SetE>>
+		: MergeOnto<T, GetE>;
 
 type Merged<PL, Base> = ModuleVars<PL> & Base;
 
@@ -17,9 +46,10 @@ type Merged<PL, Base> = ModuleVars<PL> & Base;
  * with mounted var extensions merged in by the var's declared name.
  */
 export type ScopeOf<PL, Base = unknown> = {
-	[K in keyof Merged<PL, Base>]: MergeExtension<
+	[K in keyof Merged<PL, Base>]: MergeVarValue<
 		Merged<PL, Base>[K],
-		VarExtensionsFor<PL, K & string>
+		VarExtensionsFor<PL, K & string>,
+		VarExtensionArgsFor<PL, K & string>
 	>;
 };
 
@@ -28,15 +58,18 @@ export type ScopeOf<PL, Base = unknown> = {
  * builder carries as its base scope.
  */
 export type ResolvedVars<PL> = {
-	[K in keyof ModuleVars<PL>]: MergeExtension<
+	[K in keyof ModuleVars<PL>]: MergeVarValue<
 		ModuleVars<PL>[K],
-		VarExtensionsFor<PL, K & string>
+		VarExtensionsFor<PL, K & string>,
+		VarExtensionArgsFor<PL, K & string>
 	>;
 };
 
 /** Names listed in `requires` become non-nullable. */
 export type VarScope<RV, Required> = Prettify<{
-	[K in keyof RV]: K extends Required ? NonNullable<RV[K]> : RV[K];
+	[K in keyof RV]: K extends Required
+		? NonNullable<VarGet<RV[K]>>
+		: VarGet<RV[K]>;
 }>;
 
 export type VarName<RV> = keyof RV & string;
@@ -50,11 +83,14 @@ export type VarName<RV> = keyof RV & string;
  * `c.var.session.get().userId`). `set` is always synchronous, and absent
  * entirely on a readonly frame.
  *
- * For schema vars, `T` is the write/args shape (`InferArgs`) so defaulted
- * or optional fields may be omitted in `.set(...)`.
+ * Schema vars wrap `VarSlot<InferInput, InferArgs>` so `.get()` sees the
+ * stored/post-validation shape while `.set()` accepts the caller args
+ * shape (optional / defaulted fields may be omitted).
  */
 export type VarHandle<T, RO extends boolean = false> = Prettify<
-	{ get(): T } & (RO extends true ? unknown : { set(value: T): void })
+	{ get(): VarGet<T> } & (RO extends true
+		? unknown
+		: { set(value: VarSetVal<T>): void })
 >;
 
 /** The scope as handles. A var listed in `requires` is non-null. */

--- a/packages/experimental/src/var.test.ts
+++ b/packages/experimental/src/var.test.ts
@@ -93,8 +93,8 @@ describe("var extensions", () => {
 	});
 });
 
-describe("record vars", () => {
-	const draft = v.record("vt_draft", {
+describe("merge vars", () => {
+	const draft = v.merge("vt_draft", {
 		schema: v.object({ title: v.string(), body: v.string() }),
 	});
 

--- a/packages/experimental/src/var.test.ts
+++ b/packages/experimental/src/var.test.ts
@@ -67,6 +67,40 @@ describe("var-bound input", () => {
 	});
 });
 
+describe("schema-backed set", () => {
+	const user = v.var("vt_user", {
+		default: null as { name: string; role: string } | null,
+		schema: v.object({
+			name: v.string(),
+			role: v.string({ default: "user" }),
+		}),
+	});
+
+	it("validates and applies defaults on direct set", () => {
+		const f = v.fn({ use: [{ user }] }, (c) => {
+			c.var.vt_user.set({ name: "ada" });
+			return c.var.vt_user.get();
+		});
+		expect(f()).toEqual({ name: "ada", role: "user" });
+	});
+
+	it("rejects invalid direct sets", () => {
+		const f = v.fn({ use: [{ user }] }, (c) => {
+			c.var.vt_user.set({ name: 1 } as never);
+		});
+		expect(() => f()).toThrow(/expected string/);
+	});
+
+	it("still allows clearing a nullable var with null", () => {
+		const f = v.fn({ use: [{ user }] }, (c) => {
+			c.var.vt_user.set({ name: "ada" });
+			c.var.vt_user.set(null);
+			return c.var.vt_user.get();
+		});
+		expect(f()).toBeNull();
+	});
+});
+
 describe("var extensions", () => {
 	const account = v.var("vt_account", {
 		default: null as { id: string } | null,

--- a/packages/experimental/src/var.ts
+++ b/packages/experimental/src/var.ts
@@ -6,6 +6,7 @@ import {
 	type DefineOutput,
 	type InferInput,
 	type TypeDefination,
+	validate,
 	vTypes,
 } from "./schema";
 import type { VarGet } from "./scope";
@@ -255,5 +256,16 @@ export const createVarScope = (frame: Frame): any => {
 
 const createHandle = (frame: Frame, name: string) => ({
 	get: () => readVar(frame.cells, name),
-	set: (value: unknown) => writeVar(frame, name, value),
+	set: (value: unknown) => {
+		// Direct set accepts InferArgs; store InferInput. Fn-input writes
+		// already validate before writeVar and skip this path. Merge vars
+		// keep partial state, so they skip full-schema validation here.
+		const def = varRegistry.get(name);
+		const cell = getCell(frame.cells, name);
+		let next = value;
+		if (!cell.accumulate && def?.schema !== undefined && next != null) {
+			next = validate(def.schema, next, name);
+		}
+		writeVar(frame, name, next);
+	},
 });

--- a/packages/experimental/src/var.ts
+++ b/packages/experimental/src/var.ts
@@ -8,6 +8,7 @@ import {
 	type TypeDefination,
 	vTypes,
 } from "./schema";
+import type { VarGet } from "./scope";
 import type { LiteralString, Prettify } from "./types";
 
 export interface VarDefination<
@@ -18,7 +19,7 @@ export interface VarDefination<
 > {
 	$var: true;
 	name: N;
-	default?: T;
+	default?: VarGet<T>;
 	/** Kept in the type so the var can also be used as an input field. */
 	schema?: Schema;
 	type?: T;
@@ -26,12 +27,12 @@ export interface VarDefination<
 	 * makes this one non-null too. */
 	$source?: Source;
 	customize: <S>(options: {
-		schema: (v: VarCustomizer<T>) => S;
+		schema: (v: VarCustomizer<VarGet<T>>) => S;
 	}) => VarDefination<N, InferInput<S>, S>;
 }
 
 export type ValueOfVar<SV> =
-	SV extends VarDefination<any, infer T, any, any> ? T : never;
+	SV extends VarDefination<any, infer T, any, any> ? VarGet<T> : never;
 
 export type NameOfVar<SV> =
 	SV extends VarDefination<infer N, any, any, any> ? N : never;
@@ -46,7 +47,7 @@ export type VarCustomizer<T> = typeof vTypes & {
 		shape: S,
 	) => TypeDefination<
 		DefineInput<S>,
-		Prettify<NonNullable<T> & DefineOutput<S>>
+		Prettify<NonNullable<VarGet<T>> & DefineOutput<S>>
 	>;
 	replace: <S>(schema: S) => S;
 };

--- a/packages/experimental/src/var.ts
+++ b/packages/experimental/src/var.ts
@@ -95,14 +95,14 @@ export const deriveVar = (name: string, source: any, get: any): any =>
 
 /**
  * One var's state within a scope: the current value, plus how reads and
- * writes behave for it (derived computation, record accumulation).
+ * writes behave for it (derived computation, merge accumulation).
  */
 export type Cell = {
 	value: unknown;
 	derive?: { source: string; get: (value: any) => any };
 	/** A direct write to a derived var shadows its computation. */
 	shadowed: boolean;
-	/** Record var: `set()` merges instead of replacing. */
+	/** Merge var: `set()` merges instead of replacing. */
 	accumulate: boolean;
 };
 

--- a/packages/experimental/test/adapter/assemble.ts
+++ b/packages/experimental/test/adapter/assemble.ts
@@ -1,0 +1,75 @@
+import { v } from "../../src";
+import { createDbApi } from "./db";
+import { ddl } from "./ddl";
+import type { Driver } from "./driver";
+import type { BetterAuthDBSchema } from "./types";
+
+/** App-facing options — codecs/capabilities come from `driver`. */
+export type CreateBetterDBOptions = {
+	driver: Driver;
+	schema?: BetterAuthDBSchema;
+	/** Instance-specific id factory; default is `crypto.randomUUID`. */
+	generateId?: (ctx: { model: string }) => string;
+	usePlural?: boolean;
+	defaultFindManyLimit?: number;
+	disableIdGeneration?: boolean;
+	adapterName?: string;
+};
+
+export type BetterDBInstance = {
+	schema: BetterAuthDBSchema;
+	config: {
+		adapterId: string;
+		adapterName?: string;
+		supportsJSON: boolean;
+		supportsDates: boolean;
+		supportsBooleans: boolean;
+		supportsArrays: boolean;
+		supportsJoins: boolean;
+		supportsNumericIds: boolean;
+		supportsUUIDs: boolean;
+		supportsTransactions: boolean;
+		disableIdGeneration: boolean;
+		usePlural: boolean;
+		defaultFindManyLimit: number;
+	};
+	client: unknown;
+};
+
+/**
+ * Assemble a mountable Better DB module of public `db.*` fns only.
+ * Pipeline/storage/vars stay on each fn's internal `use` chain — not leaked
+ * onto the returned module.
+ */
+export const createBetterDB = (options: CreateBetterDBOptions) => {
+	const { driver } = options;
+	const instance: BetterDBInstance = {
+		schema: options.schema ?? {},
+		config: {
+			...driver.capabilities,
+			adapterId: driver.adapterId,
+			adapterName: options.adapterName ?? driver.adapterName,
+			disableIdGeneration: options.disableIdGeneration ?? false,
+			usePlural: options.usePlural ?? false,
+			defaultFindManyLimit: options.defaultFindManyLimit ?? 100,
+		},
+		client: driver.client,
+	};
+
+	const hooks = options.generateId
+		? {
+				customGenerateId: v.on("pipeline.generateId", (c) =>
+					options.generateId!({
+						model: (c.input as { model: string }).model,
+					}),
+				),
+			}
+		: {};
+
+	return createDbApi(driver.storage, instance, hooks);
+};
+
+/** @deprecated Use `ddl` from `./ddl`. */
+export const betterDB = ddl;
+
+export type BetterDBModule = ReturnType<typeof createBetterDB>;

--- a/packages/experimental/test/adapter/bun-sqlite.d.ts
+++ b/packages/experimental/test/adapter/bun-sqlite.d.ts
@@ -1,0 +1,20 @@
+/** Minimal bun:sqlite typings for adapter tests (package has no bun-types). */
+declare module "bun:sqlite" {
+	export class Statement {
+		get(...params: unknown[]): unknown;
+		all(...params: unknown[]): unknown[];
+	}
+
+	export class Database {
+		constructor(
+			filename?: string,
+			options?: number | { readonly?: boolean; create?: boolean },
+		);
+		run(
+			sql: string,
+			params?: unknown[] | Record<string, unknown>,
+		): { changes: number; lastInsertRowid: number | bigint };
+		query(sql: string): Statement;
+		close(): void;
+	}
+}

--- a/packages/experimental/test/adapter/contract.test.ts
+++ b/packages/experimental/test/adapter/contract.test.ts
@@ -1,0 +1,369 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "vitest";
+import { ValidationError, v } from "../../src";
+import type { BetterDBModule } from "./assemble";
+import { createBetterDB } from "./assemble";
+import { memoryDriver } from "./driver";
+import { memoryDb, sqliteDb, testSchema } from "./helpers";
+import type { BetterAuthDBSchema } from "./types";
+
+const runContract = (
+	name: string,
+	create: () => Promise<BetterDBModule> | BetterDBModule,
+) => {
+	describe(`db.* contract (${name})`, () => {
+		it("create + findOne + findMany", async () => {
+			const db = await create();
+			const user = await db.create({
+				model: "user",
+				data: { name: "Ada", email: "ada@example.com", age: 36 },
+			});
+			expect(user).toMatchObject({
+				name: "Ada",
+				email: "ada@example.com",
+				age: 36,
+			});
+			expect(user.id).toBeTruthy();
+
+			const found = await db.findOne({
+				model: "user",
+				where: [{ field: "email", value: "ada@example.com" }],
+			});
+			expect(found).toMatchObject({ name: "Ada", email: "ada@example.com" });
+
+			await db.create({
+				model: "user",
+				data: { name: "Bob", email: "bob@example.com", age: 20 },
+			});
+			const many = await db.findMany({
+				model: "user",
+				where: [{ field: "age", operator: "gt", value: 30 }],
+				sortBy: { field: "name", direction: "asc" },
+			});
+			expect(many).toHaveLength(1);
+			expect(many[0]?.name).toBe("Ada");
+		});
+
+		it("supports where operators", async () => {
+			const db = await create();
+			await db.create({
+				model: "user",
+				data: { name: "Ada", email: "ada@example.com", age: 36 },
+			});
+			await db.create({
+				model: "user",
+				data: { name: "Bob", email: "bob@example.com", age: 20 },
+			});
+
+			const byIn = await db.findMany({
+				model: "user",
+				where: [{ field: "name", operator: "in", value: ["Ada", "Zoe"] }],
+			});
+			expect(byIn.map((u: any) => u.name).sort()).toEqual(["Ada"]);
+
+			const contains = await db.findMany({
+				model: "user",
+				where: [{ field: "email", operator: "contains", value: "bob" }],
+			});
+			expect(contains).toHaveLength(1);
+			expect(contains[0]?.name).toBe("Bob");
+		});
+
+		it("update / updateMany / delete / deleteMany / count", async () => {
+			const db = await create();
+			const a = await db.create({
+				model: "user",
+				data: { name: "Ada", email: "ada@example.com", age: 36 },
+			});
+			await db.create({
+				model: "user",
+				data: { name: "Bob", email: "bob@example.com", age: 20 },
+			});
+
+			const updated = await db.update({
+				model: "user",
+				where: [{ field: "id", value: a.id }],
+				update: { age: 37 },
+			});
+			expect(updated?.age).toBe(37);
+
+			const n = await db.updateMany({
+				model: "user",
+				where: [{ field: "age", operator: "lt", value: 30 }],
+				update: { active: false },
+			});
+			expect(n).toBe(1);
+
+			expect(await db.count({ model: "user" })).toBe(2);
+
+			await db.delete({
+				model: "user",
+				where: [{ field: "id", value: a.id }],
+			});
+			expect(await db.count({ model: "user" })).toBe(1);
+
+			const deleted = await db.deleteMany({
+				model: "user",
+				where: [{ field: "name", value: "Bob" }],
+			});
+			expect(deleted).toBe(1);
+			expect(await db.count({ model: "user" })).toBe(0);
+		});
+
+		it("consumeOne and incrementOne", async () => {
+			const db = await create();
+			const token = await db.create({
+				model: "token",
+				data: { value: "abc", remaining: 2 },
+			});
+
+			const consumed = await db.consumeOne({
+				model: "token",
+				where: [{ field: "id", value: token.id }],
+			});
+			expect(consumed?.value).toBe("abc");
+			expect(
+				await db.findOne({
+					model: "token",
+					where: [{ field: "id", value: token.id }],
+				}),
+			).toBeNull();
+
+			const t2 = await db.create({
+				model: "token",
+				data: { value: "xyz", remaining: 3 },
+			});
+			const inc = await db.incrementOne({
+				model: "token",
+				where: [{ field: "id", value: t2.id }],
+				increment: { remaining: -1 },
+			});
+			expect(inc?.remaining).toBe(2);
+		});
+
+		it("join fallback attaches related rows", async () => {
+			const db = await create();
+			const user = await db.create({
+				model: "user",
+				data: { name: "Ada", email: "ada@example.com" },
+			});
+			await db.create({
+				model: "session",
+				data: { userId: user.id, token: "s1" },
+			});
+			await db.create({
+				model: "session",
+				data: { userId: user.id, token: "s2" },
+			});
+
+			const found = await db.findOne({
+				model: "user",
+				where: [{ field: "id", value: user.id }],
+				join: { session: true },
+			});
+			expect(found?.name).toBe("Ada");
+			expect(Array.isArray(found?.session)).toBe(true);
+			expect(found?.session).toHaveLength(2);
+			expect(found?.session.map((s: any) => s.token).sort()).toEqual([
+				"s1",
+				"s2",
+			]);
+		});
+
+		it("rejects unknown fields on create", async () => {
+			const db = await create();
+			await expect(
+				db.create({
+					model: "user",
+					data: {
+						name: "Ada",
+						email: "ada@example.com",
+						nope: true,
+					} as any,
+				}),
+			).rejects.toThrow(ValidationError);
+		});
+
+		it("transaction scopes writes via bound tx", async () => {
+			const db = await create();
+			await db.transaction(async (tx) => {
+				await tx.create({
+					model: "user",
+					data: { name: "Ada", email: "ada@example.com" },
+				});
+			});
+			expect(await db.count({ model: "user" })).toBe(1);
+
+			await expect(
+				db.transaction(async (tx) => {
+					await tx.create({
+						model: "user",
+						data: { name: "Bob", email: "bob@example.com" },
+					});
+					throw new Error("boom");
+				}),
+			).rejects.toThrow("boom");
+			expect(await db.count({ model: "user" })).toBe(1);
+		});
+	});
+};
+
+runContract("memory", () => memoryDb());
+
+runContract("sqlite", async () => {
+	const raw = new Database(":memory:");
+	const db = sqliteDb(raw);
+	await db.applySchema({ tables: testSchema });
+	return db;
+});
+
+describe("sqlite applySchema", () => {
+	it("creates tables via generateTable", async () => {
+		const raw = new Database(":memory:");
+		const db = sqliteDb(raw);
+		const result = await db.applySchema({ tables: testSchema });
+		expect(result.code).toContain("CREATE TABLE user");
+		expect(result.code).toContain("CREATE TABLE token");
+
+		await db.create({
+			model: "user",
+			data: { name: "Ada", email: "ada@example.com" },
+		});
+		expect(await db.count({ model: "user" })).toBe(1);
+	});
+});
+
+describe("module composition", () => {
+	it("mounts db.* via use without leaking storage/pipeline", async () => {
+		const mod = memoryDb();
+		expect(mod).not.toHaveProperty("storageCreate");
+		expect(mod).not.toHaveProperty("transformInput");
+		expect(mod).not.toHaveProperty("client");
+
+		const app = v.fn({ use: [mod] }).fn(async (c) => {
+			const user = await c.use.create({
+				model: "user",
+				data: { name: "Ada", email: "ada@example.com" },
+			});
+			return c.use.findOne({
+				model: "user",
+				where: [{ field: "id", value: user.id }],
+			});
+		});
+		const row = await app();
+		expect(row).toMatchObject({ name: "Ada", email: "ada@example.com" });
+	});
+});
+
+describe("instance isolation", () => {
+	it("keeps schema and client separate across drivers", async () => {
+		const schemaA: BetterAuthDBSchema = {
+			user: {
+				fields: {
+					name: { type: "string", required: true },
+					email: { type: "string", required: true },
+				},
+			},
+		};
+		const schemaB: BetterAuthDBSchema = {
+			account: {
+				fields: {
+					handle: { type: "string", required: true },
+				},
+			},
+		};
+		const a = createBetterDB({
+			driver: memoryDriver(),
+			schema: schemaA,
+		});
+		const b = createBetterDB({
+			driver: memoryDriver(),
+			schema: schemaB,
+		});
+
+		await a.create({
+			model: "user",
+			data: { name: "Ada", email: "ada@example.com" },
+		});
+		await b.create({
+			model: "account",
+			data: { handle: "bob" },
+		});
+
+		expect(await a.count({ model: "user" })).toBe(1);
+		expect(await b.count({ model: "account" })).toBe(1);
+		await expect(
+			a.create({ model: "account", data: { handle: "x" } } as any),
+		).rejects.toThrow();
+		await expect(
+			b.create({
+				model: "user",
+				data: { name: "Zoe", email: "z@example.com" },
+			} as any),
+		).rejects.toThrow();
+	});
+});
+
+describe("create id handling", () => {
+	it("keeps a provided id on create", async () => {
+		const db = memoryDb();
+		const user = await db.create({
+			model: "user",
+			data: { id: "custom-ada", name: "Ada", email: "ada@example.com" },
+		});
+		expect(user.id).toBe("custom-ada");
+		const found = await db.findOne({
+			model: "user",
+			where: [{ field: "id", value: "custom-ada" }],
+		});
+		expect(found?.name).toBe("Ada");
+	});
+});
+
+describe("custom generateId", () => {
+	it("uses createBetterDB({ generateId }) for new rows", async () => {
+		let n = 0;
+		const db = createBetterDB({
+			driver: memoryDriver(),
+			schema: testSchema,
+			generateId: ({ model }) => `${model}-${++n}`,
+		});
+		const user = await db.create({
+			model: "user",
+			data: { name: "Ada", email: "ada@example.com" },
+		});
+		expect(user.id).toBe("user-1");
+		const token = await db.create({
+			model: "token",
+			data: { value: "abc", remaining: 1 },
+		});
+		expect(token.id).toBe("token-2");
+	});
+});
+
+describe("transaction guards", () => {
+	it("throws on nested transaction", async () => {
+		const db = memoryDb();
+		await expect(
+			db.transaction(async (tx) => {
+				await tx.transaction(async () => {});
+			}),
+		).rejects.toThrow(/nested transactions are not supported/);
+	});
+
+	it("documents that unbound db.create is not isolated by the txn", async () => {
+		const db = memoryDb();
+		await expect(
+			db.transaction(async () => {
+				// Wrong: module-level create does not participate in this txn.
+				await db.create({
+					model: "user",
+					data: { name: "Leak", email: "leak@example.com" },
+				});
+				throw new Error("rollback");
+			}),
+		).rejects.toThrow("rollback");
+		// Survives rollback — wrote outside the journal.
+		expect(await db.count({ model: "user" })).toBe(1);
+	});
+});

--- a/packages/experimental/test/adapter/db.ts
+++ b/packages/experimental/test/adapter/db.ts
@@ -337,6 +337,8 @@ export const createDbApi = (
 		"db.updateMany",
 		{ input: updateManyInput, ...withStorage },
 		withInstance(instance, async (c) => {
+			// Empty where matches every row in storage - refuse to wipe the table.
+			if (!c.input.where.length) return 0;
 			const table = c.use.getModelName({ model: c.input.model });
 			const input = c.use.transformInput({
 				model: c.input.model,
@@ -359,6 +361,7 @@ export const createDbApi = (
 		"db.delete",
 		{ input: deleteInput, ...withStorage },
 		withInstance(instance, async (c) => {
+			if (!c.input.where.length) return;
 			const table = c.use.getModelName({ model: c.input.model });
 			await c.use.storageDelete({
 				model: table,
@@ -374,6 +377,7 @@ export const createDbApi = (
 		"db.deleteMany",
 		{ input: deleteInput, ...withStorage },
 		withInstance(instance, async (c) => {
+			if (!c.input.where.length) return 0;
 			const table = c.use.getModelName({ model: c.input.model });
 			return c.use.storageDeleteMany({
 				model: table,
@@ -389,6 +393,7 @@ export const createDbApi = (
 		"db.consumeOne",
 		{ input: consumeOneInput, ...withStorage },
 		withInstance(instance, async (c) => {
+			if (!c.input.where.length) return null;
 			const table = c.use.getModelName({ model: c.input.model });
 			const where = c.use.cleanWhere({
 				model: c.input.model,
@@ -403,6 +408,7 @@ export const createDbApi = (
 		"db.incrementOne",
 		{ input: incrementOneInput, ...withStorage },
 		withInstance(instance, async (c) => {
+			if (!c.input.where.length) return null;
 			const table = c.use.getModelName({ model: c.input.model });
 			const where = c.use.cleanWhere({
 				model: c.input.model,

--- a/packages/experimental/test/adapter/db.ts
+++ b/packages/experimental/test/adapter/db.ts
@@ -1,0 +1,528 @@
+import { v } from "../../src";
+import { generateTable } from "./ddl";
+import { pipeline } from "./pipeline";
+import {
+	applySchemaInput,
+	consumeOneInput,
+	countInput,
+	createInput,
+	deleteInput,
+	findManyInput,
+	findOneInput,
+	incrementOneInput,
+	updateInput,
+	updateManyInput,
+} from "./schemas";
+import { adapterVars } from "./vars";
+
+type FieldAttr = {
+	type?: string;
+	fieldName?: string;
+	unique?: boolean;
+	bigint?: boolean;
+	required?: boolean;
+	sortable?: boolean;
+};
+
+type Schema = Record<
+	string,
+	{ modelName?: string; fields: Record<string, FieldAttr> }
+>;
+
+type StorageModule = Record<string, unknown>;
+
+type DbInstance = {
+	schema: unknown;
+	config: unknown;
+	client: unknown;
+};
+
+/**
+ * Seed this assembly's schema/config/client onto the current call scope.
+ * Does not touch `trx` — the active transaction owns that cell.
+ */
+const seedInstance = (c: any, instance: DbInstance) => {
+	c.var.schema.set(instance.schema);
+	c.var.adapterConfig.set(instance.config);
+	c.var.client.set(instance.client);
+};
+
+/** Ensure every public handler seeds before running — can't forget a call site. */
+const withInstance =
+	<R>(instance: DbInstance, body: (c: any) => R) =>
+	async (c: any): Promise<Awaited<R>> => {
+		seedInstance(c, instance);
+		return await body(c);
+	};
+
+const attachJoins = async (
+	c: any,
+	baseModel: string,
+	baseRow: Record<string, any> | null,
+	joinOpt: Record<string, unknown> | undefined,
+	select?: string[],
+) => {
+	if (!baseRow || !joinOpt || !Object.keys(joinOpt).length) {
+		return c.use.transformOutput({
+			model: baseModel,
+			data: baseRow,
+			select,
+		});
+	}
+
+	const config = c.var.adapterConfig.get() as {
+		supportsJoins?: boolean;
+	};
+	const resolved = c.use.resolveJoin({
+		model: baseModel,
+		join: joinOpt,
+		select,
+	}) as {
+		join: Record<
+			string,
+			{
+				on: { from: string; to: string };
+				limit: number;
+				relation: "one-to-one" | "one-to-many";
+				logicalModel: string;
+			}
+		>;
+		select?: string[];
+	};
+
+	const transformed = (await c.use.transformOutput({
+		model: baseModel,
+		data: baseRow,
+		select: resolved.select,
+	})) as Record<string, any>;
+
+	if (config.supportsJoins) {
+		for (const [, meta] of Object.entries(resolved.join)) {
+			const raw = baseRow[meta.logicalModel];
+			transformed[meta.logicalModel] = await c.use.transformOutput({
+				model: meta.logicalModel,
+				data: raw ?? (meta.relation === "one-to-one" ? null : []),
+			});
+		}
+		return transformed;
+	}
+
+	for (const [physicalModel, meta] of Object.entries(resolved.join)) {
+		const baseFields =
+			(c.var.schema.get() as Schema)?.[baseModel]?.fields ?? {};
+		const fromLogical =
+			Object.entries(baseFields).find(
+				([key, attr]) => (attr.fieldName ?? key) === meta.on.from,
+			)?.[0] ?? meta.on.from;
+		const value = transformed[fromLogical] ?? baseRow[meta.on.from];
+		if (value === null || value === undefined) {
+			transformed[meta.logicalModel] =
+				meta.relation === "one-to-one" ? null : [];
+			continue;
+		}
+		const where = [
+			{
+				field: meta.on.to,
+				value,
+				operator: "eq" as const,
+				connector: "AND" as const,
+				mode: "sensitive" as const,
+			},
+		];
+		if (meta.relation === "one-to-one") {
+			const joined = await c.use.storageFindOne({
+				model: physicalModel,
+				where,
+			});
+			transformed[meta.logicalModel] = await c.use.transformOutput({
+				model: meta.logicalModel,
+				data: joined,
+			});
+		} else {
+			const joined = await c.use.storageFindMany({
+				model: physicalModel,
+				where,
+				limit: meta.limit,
+			});
+			transformed[meta.logicalModel] = await Promise.all(
+				(joined as unknown[]).map((row) =>
+					c.use.transformOutput({
+						model: meta.logicalModel,
+						data: row,
+					}),
+				),
+			);
+		}
+	}
+	return transformed;
+};
+
+/** Bind public db ops to the active transaction scope (parent context). */
+const bindTx = (c: any, api: Record<string, any>) => {
+	const call = (fn: any) => (input?: unknown) => fn(input, c);
+	return {
+		create: call(api.create),
+		findOne: call(api.findOne),
+		findMany: call(api.findMany),
+		count: call(api.count),
+		update: call(api.update),
+		updateMany: call(api.updateMany),
+		delete: call(api.delete),
+		deleteMany: call(api.deleteMany),
+		consumeOne: call(api.consumeOne),
+		incrementOne: call(api.incrementOne),
+		applySchema: call(api.applySchema),
+		/** Nested begin hits the storage guard via the shared scope. */
+		transaction: (input?: unknown) => api.transaction(input, c),
+	};
+};
+
+export type Tx = ReturnType<typeof bindTx>;
+
+/**
+ * Build public `db.*` fns bound to a concrete storage module and instance bag.
+ * Storage stays on each fn's internal `use` chain (export names `storageCreate`, …).
+ */
+export const createDbApi = (
+	storage: StorageModule,
+	instance: DbInstance,
+	hooks: Record<string, unknown> = {},
+) => {
+	const withStorage = {
+		use: [adapterVars, pipeline, storage, hooks],
+	};
+
+	const create = v.fn(
+		"db.create",
+		{ input: createInput, ...withStorage },
+		withInstance(instance, async (c) => {
+			const table = c.use.getModelName({ model: c.input.model });
+			const input = c.use.transformInput({
+				model: c.input.model,
+				data: c.input.data,
+				action: "create",
+				strict: true,
+			});
+			const created = await c.use.storageCreate({
+				model: table,
+				data: input,
+				select: c.input.select,
+			});
+			return (await c.use.transformOutput({
+				model: c.input.model,
+				data: created,
+				select: c.input.select,
+			})) as Record<string, any>;
+		}),
+	);
+
+	const findOne = v.fn(
+		"db.findOne",
+		{ input: findOneInput, ...withStorage },
+		withInstance(instance, async (c) => {
+			const table = c.use.getModelName({ model: c.input.model });
+			const where = c.use.cleanWhere({
+				model: c.input.model,
+				where: c.input.where,
+			});
+			let select = c.input.select;
+			if (c.input.join && Object.keys(c.input.join).length) {
+				const resolved = c.use.resolveJoin({
+					model: c.input.model,
+					join: c.input.join,
+					select,
+				});
+				select = resolved.select;
+			}
+			const found = await c.use.storageFindOne({
+				model: table,
+				where,
+				select,
+			});
+			return attachJoins(c, c.input.model, found, c.input.join, select);
+		}),
+	);
+
+	const findMany = v.fn(
+		"db.findMany",
+		{ input: findManyInput, ...withStorage },
+		withInstance(instance, async (c) => {
+			const config = c.var.adapterConfig.get() as {
+				defaultFindManyLimit?: number;
+			};
+			const table = c.use.getModelName({ model: c.input.model });
+			const where = c.input.where
+				? c.use.cleanWhere({
+						model: c.input.model,
+						where: c.input.where,
+					})
+				: undefined;
+			let select = c.input.select;
+			if (c.input.join && Object.keys(c.input.join).length) {
+				const resolved = c.use.resolveJoin({
+					model: c.input.model,
+					join: c.input.join,
+					select,
+				});
+				select = resolved.select;
+			}
+			const sortBy = c.input.sortBy
+				? {
+						field: c.use.getFieldName({
+							model: c.input.model,
+							field: c.input.sortBy.field,
+						}),
+						direction: c.input.sortBy.direction,
+					}
+				: undefined;
+			const rows = await c.use.storageFindMany({
+				model: table,
+				where,
+				limit: c.input.limit ?? config.defaultFindManyLimit ?? 100,
+				select,
+				sortBy,
+				offset: c.input.offset,
+			});
+			return Promise.all(
+				(rows as Record<string, any>[]).map((row) =>
+					attachJoins(c, c.input.model, row, c.input.join, select),
+				),
+			);
+		}),
+	);
+
+	const count = v.fn(
+		"db.count",
+		{ input: countInput, ...withStorage },
+		withInstance(instance, async (c) => {
+			const table = c.use.getModelName({ model: c.input.model });
+			const where = c.input.where
+				? c.use.cleanWhere({
+						model: c.input.model,
+						where: c.input.where,
+					})
+				: undefined;
+			return c.use.storageCount({ model: table, where });
+		}),
+	);
+
+	const update = v.fn(
+		"db.update",
+		{ input: updateInput, ...withStorage },
+		withInstance(instance, async (c) => {
+			if (!c.input.where.length) return null;
+			const table = c.use.getModelName({ model: c.input.model });
+			const input = c.use.transformInput({
+				model: c.input.model,
+				data: c.input.update,
+				action: "update",
+				strict: true,
+			});
+			const updated = await c.use.storageUpdate({
+				model: table,
+				where: c.use.cleanWhere({
+					model: c.input.model,
+					where: c.input.where,
+				}),
+				update: input,
+			});
+			return c.use.transformOutput({
+				model: c.input.model,
+				data: updated,
+			});
+		}),
+	);
+
+	const updateMany = v.fn(
+		"db.updateMany",
+		{ input: updateManyInput, ...withStorage },
+		withInstance(instance, async (c) => {
+			const table = c.use.getModelName({ model: c.input.model });
+			const input = c.use.transformInput({
+				model: c.input.model,
+				data: c.input.update,
+				action: "update",
+				strict: true,
+			});
+			return c.use.storageUpdateMany({
+				model: table,
+				where: c.use.cleanWhere({
+					model: c.input.model,
+					where: c.input.where,
+				}),
+				update: input,
+			});
+		}),
+	);
+
+	const deleteOne = v.fn(
+		"db.delete",
+		{ input: deleteInput, ...withStorage },
+		withInstance(instance, async (c) => {
+			const table = c.use.getModelName({ model: c.input.model });
+			await c.use.storageDelete({
+				model: table,
+				where: c.use.cleanWhere({
+					model: c.input.model,
+					where: c.input.where,
+				}),
+			});
+		}),
+	);
+
+	const deleteMany = v.fn(
+		"db.deleteMany",
+		{ input: deleteInput, ...withStorage },
+		withInstance(instance, async (c) => {
+			const table = c.use.getModelName({ model: c.input.model });
+			return c.use.storageDeleteMany({
+				model: table,
+				where: c.use.cleanWhere({
+					model: c.input.model,
+					where: c.input.where,
+				}),
+			});
+		}),
+	);
+
+	const consumeOne = v.fn(
+		"db.consumeOne",
+		{ input: consumeOneInput, ...withStorage },
+		withInstance(instance, async (c) => {
+			const table = c.use.getModelName({ model: c.input.model });
+			const where = c.use.cleanWhere({
+				model: c.input.model,
+				where: c.input.where,
+			});
+			const row = await c.use.storageConsumeOne({ model: table, where });
+			return c.use.transformOutput({ model: c.input.model, data: row });
+		}),
+	);
+
+	const incrementOne = v.fn(
+		"db.incrementOne",
+		{ input: incrementOneInput, ...withStorage },
+		withInstance(instance, async (c) => {
+			const table = c.use.getModelName({ model: c.input.model });
+			const where = c.use.cleanWhere({
+				model: c.input.model,
+				where: c.input.where,
+			});
+			const row = await c.use.storageIncrementOne({
+				model: table,
+				where,
+				increment: c.input.increment,
+				set: c.input.set,
+			});
+			return c.use.transformOutput({ model: c.input.model, data: row });
+		}),
+	);
+
+	const applySchema = v.fn(
+		"db.applySchema",
+		{
+			input: applySchemaInput,
+			use: [adapterVars, pipeline, storage, hooks, { generateTable }],
+		},
+		withInstance(instance, async (c) => {
+			const schema = (c.input.tables ?? c.var.schema.get()) as Schema;
+			const statements: string[] = [];
+			for (const [key, table] of Object.entries(schema)) {
+				const name = table.modelName ?? key;
+				const fields: Record<string, FieldAttr> = {
+					id: { type: "string", unique: true, required: true },
+				};
+				for (const [field, attr] of Object.entries(table.fields)) {
+					const col = attr.fieldName ?? field;
+					fields[col] = {
+						type: attr.type ?? "string",
+						unique: attr.unique ?? false,
+						bigint: attr.bigint ?? false,
+						required: attr.required ?? true,
+						sortable: attr.sortable ?? false,
+						fieldName: attr.fieldName,
+					};
+				}
+				const sql = c.use.generateTable({ name, fields });
+				statements.push(sql);
+			}
+			await c.use.storageApplyDDL({
+				statements,
+				file: c.input.file,
+			});
+			return {
+				code: statements.join(";\n"),
+				path: c.input.file ?? "schema.sql",
+			};
+		}),
+	);
+
+	const api: Record<string, any> = {
+		create,
+		findOne,
+		findMany,
+		count,
+		update,
+		updateMany,
+		delete: deleteOne,
+		deleteMany,
+		consumeOne,
+		incrementOne,
+		applySchema,
+	};
+
+	/**
+	 * Run a callback inside a storage transaction.
+	 *
+	 * Prefer the bound handle: `db.transaction(async (tx) => tx.create(...))`.
+	 * Unbound module-level `db.create(...)` inside the callback does **not**
+	 * participate (fresh scope) and will not roll back with the transaction.
+	 */
+	type TxCallback = (tx: Tx) => unknown | Promise<unknown>;
+
+	const transaction = v.fn(
+		"db.transaction",
+		{
+			input: v.any<TxCallback>(),
+			use: [adapterVars, pipeline, storage, hooks, api],
+		},
+		withInstance(instance, async (c) => {
+			const config = c.var.adapterConfig.get() as {
+				supportsTransactions?: boolean;
+			};
+			const run = c.input;
+			if (typeof run !== "function") {
+				throw new Error("db.transaction expects a callback (tx) => ...");
+			}
+			const tx = bindTx(c, { ...api, transaction });
+			if (config.supportsTransactions === false) {
+				return run(tx);
+			}
+			await c.use.storageBegin({});
+			try {
+				const result = await run(tx);
+				await c.use.storageCommit({});
+				return result;
+			} catch (err) {
+				await c.use.storageRollback({});
+				throw err;
+			}
+		}),
+	);
+	api.transaction = transaction;
+
+	return {
+		create,
+		findOne,
+		findMany,
+		count,
+		update,
+		updateMany,
+		delete: deleteOne,
+		deleteMany,
+		consumeOne,
+		incrementOne,
+		applySchema,
+		transaction,
+	};
+};

--- a/packages/experimental/test/adapter/ddl.ts
+++ b/packages/experimental/test/adapter/ddl.ts
@@ -1,0 +1,74 @@
+import { v } from "../../src";
+import { fieldAttribute, tableAttribute } from "./field";
+import { sqliteTypes } from "./types/sqlite";
+
+/**
+ * Type packs mounted into the runner.
+ * New dialect = add its `.mappers` here.
+ */
+const typePacks = [sqliteTypes];
+const mappers = typePacks.flatMap((pack) => pack.mappers);
+
+/**
+ * Maps one field's attributes to a SQL type fragment.
+ */
+export const runMap = v.fn(
+	"types.run",
+	{ input: fieldAttribute, use: typePacks },
+	(c) => {
+		for (const m of mappers) {
+			const out = m(c.input);
+			if (out != null) return out;
+		}
+		return null;
+	},
+);
+
+/**
+ * One named column: `"id varchar(255) UNIQUE"`.
+ */
+export const generateColumn = v.fn(
+	"ddl.column",
+	{
+		input: {
+			name: v.string({ min: 1 }),
+			field: fieldAttribute,
+		},
+		use: [{ runMap }],
+	},
+	(c) => {
+		const sqlType = c.use.runMap(c.input.field);
+		if (sqlType == null) return null;
+		return `${c.input.name} ${sqlType}`;
+	},
+);
+
+/**
+ * A full table from many fields:
+ * `CREATE TABLE user (id varchar(255) UNIQUE, age int(16))`.
+ */
+export const generateTable = v.fn(
+	"ddl.table",
+	{ input: tableAttribute, use: [{ generateColumn, runMap }] },
+	(c) => {
+		const columns: string[] = [];
+		for (const [name, field] of Object.entries(c.input.fields)) {
+			const column = c.use.generateColumn({ name, field });
+			if (column == null) {
+				throw new Error(
+					`no type mapper for field "${name}" (type=${String(field.type)})`,
+				);
+			}
+			columns.push(column);
+		}
+		return `CREATE TABLE ${c.input.name} (${columns.join(", ")})`;
+	},
+);
+
+/** Mountable DDL builder (`generateColumn` / `generateTable` / type packs). */
+export const ddl = v.fn({
+	use: [...typePacks, { runMap, generateColumn, generateTable }],
+});
+
+/** @deprecated Use `ddl`. */
+export const betterDB = ddl;

--- a/packages/experimental/test/adapter/driver.ts
+++ b/packages/experimental/test/adapter/driver.ts
@@ -1,0 +1,62 @@
+import type { Database } from "bun:sqlite";
+import { createMemoryClient, memoryStorage } from "./memory";
+import { sqliteStorage } from "./sqlite";
+
+/** Wire codecs + feature flags owned by the storage driver — not app config. */
+export type DriverCapabilities = {
+	supportsJSON: boolean;
+	supportsDates: boolean;
+	supportsBooleans: boolean;
+	supportsArrays: boolean;
+	supportsJoins: boolean;
+	supportsNumericIds: boolean;
+	supportsUUIDs: boolean;
+	/** When false, `db.transaction` runs the callback without begin/commit. */
+	supportsTransactions: boolean;
+};
+
+export type Driver = {
+	adapterId: string;
+	adapterName?: string;
+	storage: Record<string, unknown>;
+	client: unknown;
+	capabilities: DriverCapabilities;
+};
+
+const baseCapabilities = {
+	supportsNumericIds: true,
+	supportsUUIDs: true,
+	supportsArrays: false,
+} as const;
+
+/** In-memory tables driver (JSON/bool/date native). */
+export const memoryDriver = (): Driver => ({
+	adapterId: "memory",
+	adapterName: "Memory",
+	storage: memoryStorage,
+	client: createMemoryClient(),
+	capabilities: {
+		...baseCapabilities,
+		supportsJSON: true,
+		supportsDates: true,
+		supportsBooleans: true,
+		supportsJoins: false,
+		supportsTransactions: true,
+	},
+});
+
+/** bun:sqlite driver (JSON stored as text). */
+export const sqliteDriver = (db: Database): Driver => ({
+	adapterId: "sqlite",
+	adapterName: "SQLite",
+	storage: sqliteStorage,
+	client: db,
+	capabilities: {
+		...baseCapabilities,
+		supportsJSON: false,
+		supportsDates: true,
+		supportsBooleans: true,
+		supportsJoins: false,
+		supportsTransactions: true,
+	},
+});

--- a/packages/experimental/test/adapter/factory.ts
+++ b/packages/experimental/test/adapter/factory.ts
@@ -1,0 +1,384 @@
+import type {
+	AdapterFactoryConfig,
+	BetterAuthDBSchema,
+	CleanedWhere,
+	CustomAdapter,
+	DBAdapter,
+	DBAdapterSchemaCreation,
+	DBFieldAttribute,
+	DBTransactionAdapter,
+	Where,
+} from "./types";
+
+/**
+ * @deprecated Legacy object-adapter factory. Prefer `createBetterDB` +
+ * `storage.*` / `db.*` modules. Kept for reference while the module path
+ * is the primary surface.
+ */
+const DEFAULT_FIND_MANY_LIMIT = 100;
+
+export const cleanWhere = (where: Where[] | undefined): CleanedWhere[] =>
+	(where ?? []).map((clause) => ({
+		field: clause.field,
+		value: clause.value,
+		operator: clause.operator ?? "eq",
+		connector: clause.connector ?? "AND",
+		mode: clause.mode ?? "sensitive",
+	}));
+
+const generateId = () => crypto.randomUUID();
+
+const getModelName = (
+	model: string,
+	schema: BetterAuthDBSchema | undefined,
+	usePlural: boolean,
+) => {
+	const table = schema?.[model];
+	if (table?.modelName) return table.modelName;
+	return usePlural ? `${model}s` : model;
+};
+
+const getFieldName = (
+	model: string,
+	field: string,
+	schema: BetterAuthDBSchema | undefined,
+) => schema?.[model]?.fields?.[field]?.fieldName ?? field;
+
+const fieldsOf = (
+	model: string,
+	schema: BetterAuthDBSchema | undefined,
+): Record<string, DBFieldAttribute> => schema?.[model]?.fields ?? {};
+
+const transformValueIn = (
+	value: unknown,
+	attr: DBFieldAttribute | undefined,
+	config: AdapterFactoryConfig,
+): unknown => {
+	if (value === undefined || value === null || !attr) return value;
+	if (attr.type === "boolean" && config.supportsBooleans === false) {
+		return value ? 1 : 0;
+	}
+	if (attr.type === "date" && config.supportsDates === false) {
+		return value instanceof Date ? value.toISOString() : value;
+	}
+	if (
+		(attr.type === "json" ||
+			attr.type === "string[]" ||
+			attr.type === "number[]") &&
+		config.supportsJSON === false
+	) {
+		return typeof value === "string" ? value : JSON.stringify(value);
+	}
+	return value;
+};
+
+const transformValueOut = (
+	value: unknown,
+	attr: DBFieldAttribute | undefined,
+	config: AdapterFactoryConfig,
+): unknown => {
+	if (value === undefined || value === null || !attr) return value;
+	if (attr.type === "boolean" && config.supportsBooleans === false) {
+		return value === 1 || value === true;
+	}
+	if (attr.type === "date" && config.supportsDates === false) {
+		return typeof value === "string" || typeof value === "number"
+			? new Date(value)
+			: value;
+	}
+	if (
+		(attr.type === "json" ||
+			attr.type === "string[]" ||
+			attr.type === "number[]") &&
+		config.supportsJSON === false
+	) {
+		if (typeof value === "string") {
+			try {
+				return JSON.parse(value);
+			} catch {
+				return value;
+			}
+		}
+	}
+	return value;
+};
+
+const transformInput = (
+	data: Record<string, unknown>,
+	model: string,
+	schema: BetterAuthDBSchema | undefined,
+	config: AdapterFactoryConfig,
+	action: "create" | "update",
+): Record<string, unknown> => {
+	const fields = fieldsOf(model, schema);
+	const out: Record<string, unknown> = {};
+
+	for (const [key, value] of Object.entries(data)) {
+		const attr = fields[key];
+		if (attr?.input === false && action === "create") continue;
+		const dbKey = getFieldName(model, key, schema);
+		out[dbKey] = transformValueIn(value, attr, config);
+	}
+
+	if (action === "create") {
+		for (const [key, attr] of Object.entries(fields)) {
+			const dbKey = attr.fieldName ?? key;
+			if (out[dbKey] !== undefined) continue;
+			if (attr.defaultValue === undefined) continue;
+			const def =
+				typeof attr.defaultValue === "function"
+					? attr.defaultValue()
+					: attr.defaultValue;
+			out[dbKey] = transformValueIn(def, attr, config);
+		}
+		// Provided id wins; otherwise generate unless disabled.
+		if (out.id === undefined && !config.disableIdGeneration) {
+			out.id = config.customIdGenerator?.({ model }) ?? generateId();
+		}
+	}
+
+	return out;
+};
+
+const transformOutput = (
+	data: Record<string, unknown> | null,
+	model: string,
+	schema: BetterAuthDBSchema | undefined,
+	config: AdapterFactoryConfig,
+	select?: string[],
+): Record<string, unknown> | null => {
+	if (!data) return null;
+	const fields = fieldsOf(model, schema);
+	const inverted = new Map<string, string>();
+	for (const [key, attr] of Object.entries(fields)) {
+		inverted.set(attr.fieldName ?? key, key);
+	}
+
+	const out: Record<string, unknown> = {};
+	for (const [dbKey, value] of Object.entries(data)) {
+		const logical = inverted.get(dbKey) ?? dbKey;
+		if (select && logical !== "id" && !select.includes(logical)) continue;
+		const attr = fields[logical];
+		if (attr?.returned === false) continue;
+		out[logical] = transformValueOut(value, attr, config);
+	}
+	return out;
+};
+
+const mapWhereFields = (
+	where: CleanedWhere[],
+	model: string,
+	schema: BetterAuthDBSchema | undefined,
+): CleanedWhere[] =>
+	where.map((clause) => ({
+		...clause,
+		field: getFieldName(model, clause.field, schema),
+	}));
+
+const rejectJoin = (join: unknown) => {
+	if (join !== undefined) {
+		throw new Error(
+			"adapter join is not implemented yet — omit join or wait for a later slice",
+		);
+	}
+};
+
+export type AdapterFactoryOptions = {
+	config: AdapterFactoryConfig;
+	adapter: (helpers: {
+		options: AdapterFactoryConfig;
+		schema: BetterAuthDBSchema;
+		getModelName: (model: string) => string;
+		getFieldName: (args: { model: string; field: string }) => string;
+	}) => CustomAdapter;
+	schema?: BetterAuthDBSchema;
+};
+
+export const createAdapterFactory = (
+	options: AdapterFactoryOptions,
+): DBAdapter => {
+	const config: AdapterFactoryConfig = {
+		supportsNumericIds: true,
+		supportsDates: true,
+		supportsBooleans: true,
+		supportsJSON: false,
+		supportsArrays: false,
+		disableIdGeneration: false,
+		usePlural: false,
+		...options.config,
+	};
+	const schema = options.schema ?? {};
+	const custom = options.adapter({
+		options: config,
+		schema,
+		getModelName: (model) => getModelName(model, schema, !!config.usePlural),
+		getFieldName: ({ model, field }) => getFieldName(model, field, schema),
+	});
+
+	const resolveModel = (model: string) =>
+		getModelName(model, schema, !!config.usePlural);
+
+	const withWhere = (model: string, where: Where[] | undefined) =>
+		mapWhereFields(cleanWhere(where), model, schema);
+
+	const runTransaction = async <R>(
+		callback: (trx: DBTransactionAdapter) => Promise<R>,
+	): Promise<R> => {
+		const txn = config.supportsTransactions ?? config.transaction;
+		if (txn === false || txn === undefined || txn === true) {
+			return callback(adapterAsTransaction());
+		}
+		return txn(callback as any) as Promise<R>;
+	};
+
+	const adapterAsTransaction = (): DBTransactionAdapter => {
+		const { transaction: _, ...rest } = api;
+		return rest;
+	};
+
+	const api: DBAdapter = {
+		id: config.adapterId,
+		options: {
+			adapterConfig: config,
+			...custom.options,
+		},
+		create: async ({ model, data, select }) => {
+			const table = resolveModel(model);
+			const input = transformInput(
+				data as Record<string, unknown>,
+				model,
+				schema,
+				config,
+				"create",
+			);
+			const created = await custom.create({
+				model: table,
+				data: input,
+				select,
+			});
+			return transformOutput(created, model, schema, config, select) as any;
+		},
+		findOne: async ({ model, where, select, join }) => {
+			rejectJoin(join);
+			const table = resolveModel(model);
+			const found = await custom.findOne({
+				model: table,
+				where: withWhere(model, where),
+				select,
+			});
+			return transformOutput(found, model, schema, config, select) as any;
+		},
+		findMany: async ({ model, where, limit, select, sortBy, offset, join }) => {
+			rejectJoin(join);
+			const table = resolveModel(model);
+			const rows = await custom.findMany({
+				model: table,
+				where: where ? withWhere(model, where) : undefined,
+				limit: limit ?? DEFAULT_FIND_MANY_LIMIT,
+				select,
+				sortBy: sortBy
+					? {
+							field: getFieldName(model, sortBy.field, schema),
+							direction: sortBy.direction,
+						}
+					: undefined,
+				offset,
+			});
+			return rows.map(
+				(row) => transformOutput(row, model, schema, config, select)!,
+			) as any;
+		},
+		count: async ({ model, where }) => {
+			const table = resolveModel(model);
+			return custom.count({
+				model: table,
+				where: where ? withWhere(model, where) : undefined,
+			});
+		},
+		update: async ({ model, where, update }) => {
+			if (!where.length) return null;
+			const table = resolveModel(model);
+			const input = transformInput(update, model, schema, config, "update");
+			const updated = await custom.update({
+				model: table,
+				where: withWhere(model, where),
+				update: input,
+			});
+			return transformOutput(updated, model, schema, config) as any;
+		},
+		updateMany: async ({ model, where, update }) => {
+			const table = resolveModel(model);
+			const input = transformInput(update, model, schema, config, "update");
+			return custom.updateMany({
+				model: table,
+				where: withWhere(model, where),
+				update: input,
+			});
+		},
+		delete: async ({ model, where }) => {
+			const table = resolveModel(model);
+			await custom.delete({
+				model: table,
+				where: withWhere(model, where),
+			});
+		},
+		deleteMany: async ({ model, where }) => {
+			const table = resolveModel(model);
+			return custom.deleteMany({
+				model: table,
+				where: withWhere(model, where),
+			});
+		},
+		consumeOne: async ({ model, where }) => {
+			if (custom.consumeOne) {
+				const table = resolveModel(model);
+				const row = await custom.consumeOne({
+					model: table,
+					where: withWhere(model, where),
+				});
+				return transformOutput(row, model, schema, config) as any;
+			}
+			return runTransaction(async (trx) => {
+				const rows = await trx.findMany({ model, where, limit: 1 });
+				const row = rows[0];
+				if (!row) return null;
+				const deleted = await trx.deleteMany({ model, where });
+				return deleted > 0 ? (row as any) : null;
+			});
+		},
+		incrementOne: async ({ model, where, increment, set }) => {
+			if (custom.incrementOne) {
+				const table = resolveModel(model);
+				const row = await custom.incrementOne({
+					model: table,
+					where: withWhere(model, where),
+					increment,
+					set,
+				});
+				return transformOutput(row, model, schema, config) as any;
+			}
+			return runTransaction(async (trx) => {
+				const rows = await trx.findMany({ model, where, limit: 1 });
+				const row = rows[0] as Record<string, any> | undefined;
+				if (!row) return null;
+				const update: Record<string, any> = { ...(set ?? {}) };
+				for (const [field, delta] of Object.entries(increment)) {
+					update[field] = Number(row[field] ?? 0) + delta;
+				}
+				const idWhere = row.id ? [{ field: "id", value: row.id }] : where;
+				return trx.update({ model, where: idWhere, update });
+			});
+		},
+		transaction: (callback) => runTransaction(callback),
+		applySchema: custom.createSchema
+			? async (props): Promise<DBAdapterSchemaCreation> =>
+					custom.createSchema!(props)
+			: undefined,
+		createSchema: custom.createSchema
+			? async (props): Promise<DBAdapterSchemaCreation> =>
+					custom.createSchema!(props)
+			: undefined,
+	};
+
+	return api;
+};

--- a/packages/experimental/test/adapter/factory.ts
+++ b/packages/experimental/test/adapter/factory.ts
@@ -307,6 +307,7 @@ export const createAdapterFactory = (
 			return transformOutput(updated, model, schema, config) as any;
 		},
 		updateMany: async ({ model, where, update }) => {
+			if (!where.length) return 0;
 			const table = resolveModel(model);
 			const input = transformInput(update, model, schema, config, "update");
 			return custom.updateMany({
@@ -316,6 +317,7 @@ export const createAdapterFactory = (
 			});
 		},
 		delete: async ({ model, where }) => {
+			if (!where.length) return;
 			const table = resolveModel(model);
 			await custom.delete({
 				model: table,
@@ -323,6 +325,7 @@ export const createAdapterFactory = (
 			});
 		},
 		deleteMany: async ({ model, where }) => {
+			if (!where.length) return 0;
 			const table = resolveModel(model);
 			return custom.deleteMany({
 				model: table,
@@ -330,6 +333,7 @@ export const createAdapterFactory = (
 			});
 		},
 		consumeOne: async ({ model, where }) => {
+			if (!where.length) return null;
 			if (custom.consumeOne) {
 				const table = resolveModel(model);
 				const row = await custom.consumeOne({
@@ -347,6 +351,7 @@ export const createAdapterFactory = (
 			});
 		},
 		incrementOne: async ({ model, where, increment, set }) => {
+			if (!where.length) return null;
 			if (custom.incrementOne) {
 				const table = resolveModel(model);
 				const row = await custom.incrementOne({

--- a/packages/experimental/test/adapter/field.ts
+++ b/packages/experimental/test/adapter/field.ts
@@ -1,0 +1,43 @@
+import { v } from "../../src";
+
+/**
+ * Column attributes aligned with better-auth `DBFieldAttribute`.
+ * Shared by DDL mappers and the adapter `schema` var.
+ * `type` stays a string so dialect mappers can return null for unknowns.
+ */
+export const fieldAttribute = v.object({
+	type: v.string({ default: "string" }),
+	required: v.boolean({ optional: true, default: true }),
+	returned: v.boolean({ optional: true, default: true }),
+	input: v.boolean({ optional: true, default: true }),
+	unique: v.boolean({ optional: true, default: false }),
+	bigint: v.boolean({ optional: true, default: false }),
+	sortable: v.boolean({ optional: true, default: false }),
+	fieldName: v.string({ optional: true }),
+	defaultValue: v.any({ optional: true }),
+	references: v.object(
+		{
+			model: v.string(),
+			field: v.string(),
+			onDelete: v.enum(
+				["no action", "restrict", "cascade", "set null", "set default"],
+				{ optional: true },
+			),
+		},
+		{ optional: true },
+	),
+});
+
+/** A named table: field name → attributes. */
+export const tableAttribute = v.object({
+	name: v.string(),
+	fields: v.record(fieldAttribute),
+});
+
+/** Better Auth schema: logical model → table def. */
+export const dbTable = v.object({
+	modelName: v.string({ optional: true }),
+	fields: v.record(fieldAttribute),
+});
+
+export const dbSchema = v.record(dbTable);

--- a/packages/experimental/test/adapter/helpers.ts
+++ b/packages/experimental/test/adapter/helpers.ts
@@ -1,0 +1,49 @@
+import type { Database } from "bun:sqlite";
+import type { BetterDBModule } from "./assemble";
+import { createBetterDB } from "./assemble";
+import { memoryDriver, sqliteDriver } from "./driver";
+import type { BetterAuthDBSchema } from "./types";
+
+export const testSchema: BetterAuthDBSchema = {
+	user: {
+		fields: {
+			name: { type: "string", required: true },
+			email: { type: "string", unique: true, required: true },
+			age: { type: "number", required: false },
+			active: { type: "boolean", required: false, defaultValue: true },
+		},
+	},
+	token: {
+		fields: {
+			value: { type: "string", required: true },
+			remaining: { type: "number", required: true, defaultValue: 3 },
+		},
+	},
+	session: {
+		fields: {
+			userId: {
+				type: "string",
+				required: true,
+				references: { model: "user", field: "id" },
+			},
+			token: { type: "string", required: true },
+		},
+	},
+};
+
+export const memoryDb = (
+	schema: BetterAuthDBSchema = testSchema,
+): BetterDBModule =>
+	createBetterDB({
+		driver: memoryDriver(),
+		schema,
+	});
+
+export const sqliteDb = (
+	db: Database,
+	schema: BetterAuthDBSchema = testSchema,
+): BetterDBModule =>
+	createBetterDB({
+		driver: sqliteDriver(db),
+		schema,
+	});

--- a/packages/experimental/test/adapter/index.ts
+++ b/packages/experimental/test/adapter/index.ts
@@ -1,0 +1,8 @@
+export { createBetterDB } from "./assemble";
+export { betterDB, ddl, generateColumn, generateTable, runMap } from "./ddl";
+export type { Driver, DriverCapabilities } from "./driver";
+export { memoryDriver, sqliteDriver } from "./driver";
+export { dbSchema, dbTable, fieldAttribute, tableAttribute } from "./field";
+export { assemble, modifiers } from "./sql";
+export type * from "./types";
+export { sqliteTypes } from "./types/sqlite";

--- a/packages/experimental/test/adapter/memory-store.ts
+++ b/packages/experimental/test/adapter/memory-store.ts
@@ -1,0 +1,143 @@
+import type { CleanedWhere, SortBy } from "./types";
+
+type Row = Record<string, any>;
+type Tables = Map<string, Row[]>;
+
+export type MemoryClient = {
+	tables: Tables;
+};
+
+export type MemoryTrx = {
+	tables: Tables;
+};
+
+const matchClause = (row: Row, clause: CleanedWhere): boolean => {
+	const raw = row[clause.field];
+	const value = clause.value;
+	const left =
+		clause.mode === "insensitive" && typeof raw === "string"
+			? raw.toLowerCase()
+			: raw;
+	const right =
+		clause.mode === "insensitive" && typeof value === "string"
+			? value.toLowerCase()
+			: value;
+
+	switch (clause.operator) {
+		case "eq":
+			return left === right;
+		case "ne":
+			return left !== right;
+		case "lt":
+			return left < (right as any);
+		case "lte":
+			return left <= (right as any);
+		case "gt":
+			return left > (right as any);
+		case "gte":
+			return left >= (right as any);
+		case "in":
+			return Array.isArray(right) && right.includes(left as never);
+		case "not_in":
+			return Array.isArray(right) && !right.includes(left as never);
+		case "contains":
+			return (
+				typeof left === "string" &&
+				typeof right === "string" &&
+				left.includes(right)
+			);
+		case "starts_with":
+			return (
+				typeof left === "string" &&
+				typeof right === "string" &&
+				left.startsWith(right)
+			);
+		case "ends_with":
+			return (
+				typeof left === "string" &&
+				typeof right === "string" &&
+				left.endsWith(right)
+			);
+		default:
+			return left === right;
+	}
+};
+
+export const matchWhere = (row: Row, where: CleanedWhere[] | undefined) => {
+	if (!where?.length) return true;
+	let result = matchClause(row, where[0]!);
+	for (let i = 1; i < where.length; i++) {
+		const clause = where[i]!;
+		const next = matchClause(row, clause);
+		result = clause.connector === "OR" ? result || next : result && next;
+	}
+	return result;
+};
+
+const sortRows = (rows: Row[], sortBy?: SortBy) => {
+	if (!sortBy) return rows;
+	const { field, direction } = sortBy;
+	return [...rows].sort((a, b) => {
+		const av = a[field];
+		const bv = b[field];
+		if (av === bv) return 0;
+		if (av == null) return 1;
+		if (bv == null) return -1;
+		const cmp = av < bv ? -1 : 1;
+		return direction === "asc" ? cmp : -cmp;
+	});
+};
+
+const pick = (row: Row, select?: string[]) => {
+	if (!select?.length) return { ...row };
+	const out: Row = {};
+	if ("id" in row) out.id = row.id;
+	for (const key of select) out[key] = row[key];
+	return out;
+};
+
+const tableOf = (tables: Tables, model: string) => {
+	let rows = tables.get(model);
+	if (!rows) {
+		rows = [];
+		tables.set(model, rows);
+	}
+	return rows;
+};
+
+const cloneTables = (tables: Tables): Tables => {
+	const out: Tables = new Map();
+	for (const [name, rows] of tables) {
+		out.set(
+			name,
+			rows.map((r) => ({ ...r })),
+		);
+	}
+	return out;
+};
+
+/** Active tables: transaction journal if present, else client. */
+export const activeTables = (
+	client: MemoryClient | null,
+	trx: MemoryTrx | null,
+): Tables => {
+	if (trx?.tables) return trx.tables;
+	if (!client?.tables) {
+		throw new Error("memory storage: client var is not set");
+	}
+	return client.tables;
+};
+
+export const createMemoryClient = (): MemoryClient => ({
+	tables: new Map(),
+});
+
+export const beginMemoryTrx = (client: MemoryClient): MemoryTrx => ({
+	tables: cloneTables(client.tables),
+});
+
+export const commitMemoryTrx = (client: MemoryClient, trx: MemoryTrx) => {
+	client.tables = trx.tables;
+};
+
+export { pick, sortRows, tableOf };

--- a/packages/experimental/test/adapter/memory.ts
+++ b/packages/experimental/test/adapter/memory.ts
@@ -1,0 +1,243 @@
+import { v } from "../../src";
+import type { MemoryClient, MemoryTrx } from "./memory-store";
+import {
+	activeTables,
+	beginMemoryTrx,
+	commitMemoryTrx,
+	createMemoryClient,
+	matchWhere,
+	pick,
+	sortRows,
+	tableOf,
+} from "./memory-store";
+import {
+	storageApplyDDLInput,
+	storageCountInput,
+	storageCreateInput,
+	storageDeleteInput,
+	storageFindManyInput,
+	storageFindOneInput,
+	storageIncrementInput,
+	storageUpdateInput,
+} from "./schemas";
+import { adapterVars } from "./vars";
+
+const storeUse = { use: [adapterVars] };
+
+const readStore = (c: {
+	var: { client: { get: () => unknown }; trx: { get: () => unknown } };
+}) =>
+	activeTables(
+		c.var.client.get() as MemoryClient | null,
+		c.var.trx.get() as MemoryTrx | null,
+	);
+
+export const storageCreate = v.fn(
+	"storage.create",
+	{ input: storageCreateInput, ...storeUse },
+	(c) => {
+		const tables = readStore(c);
+		const rows = tableOf(tables, c.input.model);
+		const row = { ...c.input.data };
+		rows.push(row);
+		return pick(row, c.input.select);
+	},
+);
+
+export const storageFindOne = v.fn(
+	"storage.findOne",
+	{ input: storageFindOneInput, ...storeUse },
+	(c) => {
+		const tables = readStore(c);
+		const row = tableOf(tables, c.input.model).find((r) =>
+			matchWhere(r, c.input.where),
+		);
+		return row ? pick(row, c.input.select) : null;
+	},
+);
+
+export const storageFindMany = v.fn(
+	"storage.findMany",
+	{ input: storageFindManyInput, ...storeUse },
+	(c) => {
+		const tables = readStore(c);
+		let rows = tableOf(tables, c.input.model).filter((r) =>
+			matchWhere(r, c.input.where),
+		);
+		rows = sortRows(rows, c.input.sortBy);
+		const start = c.input.offset ?? 0;
+		return rows
+			.slice(start, start + c.input.limit)
+			.map((r) => pick(r, c.input.select));
+	},
+);
+
+export const storageCount = v.fn(
+	"storage.count",
+	{ input: storageCountInput, ...storeUse },
+	(c) => {
+		const tables = readStore(c);
+		return tableOf(tables, c.input.model).filter((r) =>
+			matchWhere(r, c.input.where),
+		).length;
+	},
+);
+
+export const storageUpdate = v.fn(
+	"storage.update",
+	{ input: storageUpdateInput, ...storeUse },
+	(c) => {
+		const tables = readStore(c);
+		const rows = tableOf(tables, c.input.model);
+		const idx = rows.findIndex((r) => matchWhere(r, c.input.where));
+		if (idx < 0) return null;
+		rows[idx] = { ...rows[idx], ...c.input.update };
+		return { ...rows[idx] };
+	},
+);
+
+export const storageUpdateMany = v.fn(
+	"storage.updateMany",
+	{ input: storageUpdateInput, ...storeUse },
+	(c) => {
+		const tables = readStore(c);
+		const rows = tableOf(tables, c.input.model);
+		let count = 0;
+		for (let i = 0; i < rows.length; i++) {
+			if (!matchWhere(rows[i]!, c.input.where)) continue;
+			rows[i] = { ...rows[i], ...c.input.update };
+			count++;
+		}
+		return count;
+	},
+);
+
+export const storageDelete = v.fn(
+	"storage.delete",
+	{ input: storageDeleteInput, ...storeUse },
+	(c) => {
+		const tables = readStore(c);
+		const rows = tableOf(tables, c.input.model);
+		const idx = rows.findIndex((r) => matchWhere(r, c.input.where));
+		if (idx >= 0) rows.splice(idx, 1);
+	},
+);
+
+export const storageDeleteMany = v.fn(
+	"storage.deleteMany",
+	{ input: storageDeleteInput, ...storeUse },
+	(c) => {
+		const tables = readStore(c);
+		const rows = tableOf(tables, c.input.model);
+		const keep: Record<string, any>[] = [];
+		let deleted = 0;
+		for (const row of rows) {
+			if (matchWhere(row, c.input.where)) deleted++;
+			else keep.push(row);
+		}
+		tables.set(c.input.model, keep);
+		return deleted;
+	},
+);
+
+/** Fallback: find + delete in one shot against the active store. */
+export const storageConsumeOne = v.fn(
+	"storage.consumeOne",
+	{ input: storageDeleteInput, ...storeUse },
+	(c) => {
+		const tables = readStore(c);
+		const rows = tableOf(tables, c.input.model);
+		const idx = rows.findIndex((r) => matchWhere(r, c.input.where));
+		if (idx < 0) return null;
+		const [row] = rows.splice(idx, 1);
+		return row ? { ...row } : null;
+	},
+);
+
+/** Fallback: read-modify-write increment. */
+export const storageIncrementOne = v.fn(
+	"storage.incrementOne",
+	{ input: storageIncrementInput, ...storeUse },
+	(c) => {
+		const tables = readStore(c);
+		const rows = tableOf(tables, c.input.model);
+		const idx = rows.findIndex((r) => matchWhere(r, c.input.where));
+		if (idx < 0) return null;
+		const row = { ...rows[idx], ...(c.input.set ?? {}) };
+		for (const [field, delta] of Object.entries(c.input.increment)) {
+			row[field] = Number(row[field] ?? 0) + delta;
+		}
+		rows[idx] = row;
+		return { ...row };
+	},
+);
+
+export const storageApplyDDL = v.fn(
+	"storage.applyDDL",
+	{ input: storageApplyDDLInput, ...storeUse },
+	() => {
+		/* memory has no DDL to execute */
+		return { applied: 0 };
+	},
+);
+
+export const storageBegin = v.fn(
+	"storage.begin",
+	{ input: v.object({}), ...storeUse },
+	(c) => {
+		if (c.var.trx.get() != null) {
+			throw new Error("nested transactions are not supported");
+		}
+		const client = c.var.client.get() as MemoryClient | null;
+		if (!client) throw new Error("memory storage: client var is not set");
+		const journal = beginMemoryTrx(client);
+		c.var.trx.set(journal);
+		return { ok: true };
+	},
+);
+
+export const storageCommit = v.fn(
+	"storage.commit",
+	{ input: v.object({}), ...storeUse },
+	(c) => {
+		const client = c.var.client.get() as MemoryClient | null;
+		const journal = c.var.trx.get() as MemoryTrx | null;
+		if (!client || !journal) return { ok: false };
+		commitMemoryTrx(client, journal);
+		c.var.trx.set(null);
+		return { ok: true };
+	},
+);
+
+export const storageRollback = v.fn(
+	"storage.rollback",
+	{ input: v.object({}), ...storeUse },
+	(c) => {
+		c.var.trx.set(null);
+		return { ok: true };
+	},
+);
+
+/**
+ * Storage module for `createDbApi` / drivers.
+ * Export names are camelCase (`storageCreate`) for flat `c.use`; fn keys stay
+ * dotted (`storage.create`) for interceptors.
+ */
+export const memoryStorage = {
+	storageCreate,
+	storageFindOne,
+	storageFindMany,
+	storageCount,
+	storageUpdate,
+	storageUpdateMany,
+	storageDelete,
+	storageDeleteMany,
+	storageConsumeOne,
+	storageIncrementOne,
+	storageApplyDDL,
+	storageBegin,
+	storageCommit,
+	storageRollback,
+};
+
+export { createMemoryClient };

--- a/packages/experimental/test/adapter/pipeline.ts
+++ b/packages/experimental/test/adapter/pipeline.ts
@@ -1,0 +1,452 @@
+import { ValidationError, v } from "../../src";
+import { adapterVars } from "./vars";
+
+type FieldAttr = {
+	type?: string;
+	required?: boolean;
+	returned?: boolean;
+	input?: boolean;
+	unique?: boolean;
+	bigint?: boolean;
+	fieldName?: string;
+	defaultValue?: unknown;
+	references?: { model: string; field: string };
+};
+
+type Schema = Record<
+	string,
+	{ modelName?: string; fields: Record<string, FieldAttr> }
+>;
+
+type Config = {
+	supportsJSON?: boolean;
+	supportsDates?: boolean;
+	supportsBooleans?: boolean;
+	disableIdGeneration?: boolean;
+	usePlural?: boolean;
+	defaultFindManyLimit?: number;
+	supportsJoins?: boolean;
+	supportsTransactions?: boolean;
+	adapterId?: string;
+};
+
+const vars = { use: [adapterVars] };
+
+export const getModelName = v.fn(
+	"pipeline.getModelName",
+	{ input: { model: v.string() }, ...vars },
+	(c) => {
+		const schema = c.var.schema.get() as Schema;
+		const config = c.var.adapterConfig.get() as Config;
+		const table = schema?.[c.input.model];
+		if (table?.modelName) return table.modelName;
+		return config.usePlural ? `${c.input.model}s` : c.input.model;
+	},
+);
+
+export const getFieldName = v.fn(
+	"pipeline.getFieldName",
+	{ input: { model: v.string(), field: v.string() }, ...vars },
+	(c) => {
+		const schema = c.var.schema.get() as Schema;
+		return (
+			schema?.[c.input.model]?.fields?.[c.input.field]?.fieldName ??
+			c.input.field
+		);
+	},
+);
+
+export const cleanWhere = v.fn(
+	"pipeline.cleanWhere",
+	{
+		input: {
+			model: v.string(),
+			where: v.array(v.any(), { optional: true }),
+		},
+		use: [adapterVars, { getFieldName }],
+	},
+	(c) => {
+		const schema = c.var.schema.get() as Schema;
+		const config = c.var.adapterConfig.get() as Config;
+		const where = (c.input.where ?? []) as Array<{
+			field: string;
+			value: unknown;
+			operator?: string;
+			connector?: string;
+			mode?: string;
+		}>;
+		return where.map((clause) => {
+			const attr = schema?.[c.input.model]?.fields?.[clause.field];
+			let value = clause.value;
+			if (
+				attr?.type === "boolean" &&
+				typeof value === "boolean" &&
+				config.supportsBooleans === false
+			) {
+				value = value ? 1 : 0;
+			}
+			if (
+				attr?.type === "date" &&
+				value instanceof Date &&
+				config.supportsDates === false
+			) {
+				value = value.toISOString();
+			}
+			if (
+				(attr?.type === "json" ||
+					attr?.type === "string[]" ||
+					attr?.type === "number[]") &&
+				config.supportsJSON === false &&
+				typeof value === "object" &&
+				value !== null
+			) {
+				value = JSON.stringify(value);
+			}
+			return {
+				field: c.use.getFieldName({
+					model: c.input.model,
+					field: clause.field,
+				}),
+				value,
+				operator: clause.operator ?? "eq",
+				connector: clause.connector ?? "AND",
+				mode: clause.mode ?? "sensitive",
+			};
+		});
+	},
+);
+
+const transformValueIn = (
+	value: unknown,
+	attr: FieldAttr | undefined,
+	config: Config,
+): unknown => {
+	if (value === undefined || value === null || !attr) return value;
+	if (attr.type === "boolean" && config.supportsBooleans === false) {
+		return value ? 1 : 0;
+	}
+	if (attr.type === "date" && config.supportsDates === false) {
+		return value instanceof Date ? value.toISOString() : value;
+	}
+	if (
+		(attr.type === "json" ||
+			attr.type === "string[]" ||
+			attr.type === "number[]") &&
+		config.supportsJSON === false
+	) {
+		return typeof value === "string" ? value : JSON.stringify(value);
+	}
+	return value;
+};
+
+const transformValueOut = (
+	value: unknown,
+	attr: FieldAttr | undefined,
+	config: Config,
+): unknown => {
+	if (value === undefined || value === null || !attr) return value;
+	if (attr.type === "boolean" && config.supportsBooleans === false) {
+		return value === 1 || value === true;
+	}
+	if (attr.type === "date" && config.supportsDates === false) {
+		return typeof value === "string" || typeof value === "number"
+			? new Date(value)
+			: value;
+	}
+	if (
+		(attr.type === "json" ||
+			attr.type === "string[]" ||
+			attr.type === "number[]") &&
+		config.supportsJSON === false
+	) {
+		if (typeof value === "string") {
+			try {
+				return JSON.parse(value);
+			} catch {
+				return value;
+			}
+		}
+	}
+	return value;
+};
+
+const typeMatches = (attr: FieldAttr, value: unknown): boolean => {
+	if (value === null || value === undefined) return true;
+	switch (attr.type) {
+		case "string":
+			return typeof value === "string";
+		case "number":
+			return typeof value === "number";
+		case "boolean":
+			return typeof value === "boolean";
+		case "date":
+			return value instanceof Date || typeof value === "string";
+		case "json":
+			return typeof value === "object";
+		case "string[]":
+			return Array.isArray(value) && value.every((x) => typeof x === "string");
+		case "number[]":
+			return Array.isArray(value) && value.every((x) => typeof x === "number");
+		default:
+			return true;
+	}
+};
+
+export const validateData = v.fn(
+	"pipeline.validateData",
+	{
+		input: {
+			model: v.string(),
+			data: v.record(v.any()),
+			action: v.enum(["create", "update"]),
+			strict: v.boolean({ optional: true, default: true }),
+		},
+		...vars,
+	},
+	(c) => {
+		if (!c.input.strict) return c.input.data;
+		const schema = c.var.schema.get() as Schema;
+		const fields = schema?.[c.input.model]?.fields ?? {};
+		const data = c.input.data;
+		const issues: { path: string; message: string }[] = [];
+
+		for (const key of Object.keys(data)) {
+			if (key === "id") continue;
+			if (!(key in fields)) {
+				issues.push({
+					path: `data.${key}`,
+					message: `unknown field "${key}" on model "${c.input.model}"`,
+				});
+			}
+		}
+
+		if (c.input.action === "create") {
+			for (const [key, attr] of Object.entries(fields)) {
+				if (attr.input === false) continue;
+				if (attr.required === false) continue;
+				if (attr.defaultValue !== undefined) continue;
+				if (data[key] !== undefined) continue;
+				issues.push({
+					path: `data.${key}`,
+					message: `required field "${key}" is missing`,
+				});
+			}
+		}
+
+		for (const [key, value] of Object.entries(data)) {
+			if (key === "id") continue;
+			const attr = fields[key];
+			if (!attr || value === undefined) continue;
+			if (!typeMatches(attr, value)) {
+				issues.push({
+					path: `data.${key}`,
+					message: `expected ${attr.type}, received ${typeof value}`,
+				});
+			}
+		}
+
+		if (issues[0]) {
+			throw new ValidationError(issues[0].path, issues[0].message, issues);
+		}
+		return data;
+	},
+);
+
+export const generateId = v.fn(
+	"pipeline.generateId",
+	{ input: { model: v.string() }, ...vars },
+	() => crypto.randomUUID(),
+);
+
+export const transformInput = v.fn(
+	"pipeline.transformInput",
+	{
+		input: {
+			model: v.string(),
+			data: v.record(v.any()),
+			action: v.enum(["create", "update"]),
+			strict: v.boolean({ optional: true, default: true }),
+		},
+		use: [adapterVars, { getFieldName, validateData, generateId }],
+	},
+	(c) => {
+		const schema = c.var.schema.get() as Schema;
+		const config = c.var.adapterConfig.get() as Config;
+		const data = c.use.validateData(c.input) as Record<string, unknown>;
+		const fields = schema?.[c.input.model]?.fields ?? {};
+		const out: Record<string, unknown> = {};
+
+		for (const [key, value] of Object.entries(data)) {
+			const attr = fields[key];
+			if (attr?.input === false && c.input.action === "create") continue;
+			const dbKey = c.use.getFieldName({ model: c.input.model, field: key });
+			out[dbKey] = transformValueIn(value, attr, config);
+		}
+
+		if (c.input.action === "create") {
+			for (const [key, attr] of Object.entries(fields)) {
+				const dbKey = attr.fieldName ?? key;
+				if (out[dbKey] !== undefined) continue;
+				if (attr.defaultValue === undefined) continue;
+				const def =
+					typeof attr.defaultValue === "function"
+						? (attr.defaultValue as () => unknown)()
+						: attr.defaultValue;
+				out[dbKey] = transformValueIn(def, attr, config);
+			}
+			// Provided id wins; otherwise generate unless disabled.
+			if (out.id === undefined && !config.disableIdGeneration) {
+				out.id = c.use.generateId({ model: c.input.model });
+			}
+		}
+
+		return out;
+	},
+);
+
+export const transformOutput = v.fn(
+	"pipeline.transformOutput",
+	{
+		input: {
+			model: v.string(),
+			data: v.any(),
+			select: v.array(v.string(), { optional: true }),
+		},
+		...vars,
+	},
+	(c) => {
+		const data = c.input.data as Record<string, any> | null;
+		if (!data) return null;
+		const schema = c.var.schema.get() as Schema;
+		const config = c.var.adapterConfig.get() as Config;
+		const fields = schema?.[c.input.model]?.fields ?? {};
+		const inverted = new Map<string, string>();
+		for (const [key, attr] of Object.entries(fields)) {
+			inverted.set(attr.fieldName ?? key, key);
+		}
+		const out: Record<string, any> = {};
+		for (const [dbKey, value] of Object.entries(data)) {
+			const logical = inverted.get(dbKey) ?? dbKey;
+			if (
+				c.input.select &&
+				logical !== "id" &&
+				!c.input.select.includes(logical)
+			) {
+				continue;
+			}
+			const attr = fields[logical];
+			if (attr?.returned === false) continue;
+			out[logical] = transformValueOut(value, attr, config);
+		}
+		return out;
+	},
+);
+
+export const resolveJoin = v.fn(
+	"pipeline.resolveJoin",
+	{
+		input: {
+			model: v.string(),
+			join: v.record(v.any()),
+			select: v.array(v.string(), { optional: true }),
+		},
+		...vars,
+	},
+	(c) => {
+		const schema = c.var.schema.get() as Schema;
+		const config = c.var.adapterConfig.get() as Config;
+		const select = c.input.select ? [...c.input.select] : undefined;
+		const transformed: Record<
+			string,
+			{
+				on: { from: string; to: string };
+				limit: number;
+				relation: "one-to-one" | "one-to-many";
+				logicalModel: string;
+			}
+		> = {};
+
+		for (const [model, join] of Object.entries(c.input.join)) {
+			if (!join) continue;
+			const joinFields = schema?.[model]?.fields ?? {};
+			const baseFields = schema?.[c.input.model]?.fields ?? {};
+
+			let foreignKeys = Object.entries(joinFields).filter(
+				([, attr]) => attr.references?.model === c.input.model,
+			);
+			let isForward = true;
+			if (!foreignKeys.length) {
+				foreignKeys = Object.entries(baseFields).filter(
+					([, attr]) => attr.references?.model === model,
+				);
+				isForward = false;
+			}
+			if (!foreignKeys.length) {
+				throw new ValidationError(
+					"join",
+					`No foreign key found for model ${model} and base model ${c.input.model}`,
+				);
+			}
+			if (foreignKeys.length > 1) {
+				throw new ValidationError(
+					"join",
+					`Multiple foreign keys found for model ${model} and base model ${c.input.model}`,
+				);
+			}
+			const [foreignKey, foreignKeyAttributes] = foreignKeys[0]!;
+			const refs = foreignKeyAttributes.references!;
+
+			let fromLogical: string;
+			let toLogical: string;
+			let requiredSelectField: string;
+			if (isForward) {
+				requiredSelectField = refs.field;
+				fromLogical = refs.field;
+				toLogical = foreignKey;
+			} else {
+				requiredSelectField = foreignKey;
+				fromLogical = foreignKey;
+				toLogical = refs.field;
+			}
+			if (select && !select.includes(requiredSelectField)) {
+				select.push(requiredSelectField);
+			}
+
+			const isUnique =
+				toLogical === "id" ? true : (foreignKeyAttributes.unique ?? false);
+			let limit = config.defaultFindManyLimit ?? 100;
+			if (isUnique) limit = 1;
+			else if (
+				typeof join === "object" &&
+				typeof (join as any).limit === "number"
+			) {
+				limit = (join as any).limit;
+			}
+
+			const physicalModel =
+				schema?.[model]?.modelName ?? (config.usePlural ? `${model}s` : model);
+
+			transformed[physicalModel] = {
+				on: {
+					from: baseFields[fromLogical]?.fieldName ?? fromLogical,
+					to: joinFields[toLogical]?.fieldName ?? toLogical,
+				},
+				limit,
+				relation: isUnique ? "one-to-one" : "one-to-many",
+				logicalModel: model,
+			};
+		}
+		return { join: transformed, select };
+	},
+);
+
+export const pipeline = {
+	getModelName,
+	getFieldName,
+	cleanWhere,
+	validateData,
+	generateId,
+	transformInput,
+	transformOutput,
+	resolveJoin,
+};

--- a/packages/experimental/test/adapter/pipeline.ts
+++ b/packages/experimental/test/adapter/pipeline.ts
@@ -408,8 +408,16 @@ export const resolveJoin = v.fn(
 				fromLogical = foreignKey;
 				toLogical = refs.field;
 			}
-			if (select && !select.includes(requiredSelectField)) {
-				select.push(requiredSelectField);
+			// Storage rows use physical column names; push the mapped
+			// fieldName so a projected join key is not dropped as undefined.
+			const requiredPhysical =
+				baseFields[requiredSelectField]?.fieldName ?? requiredSelectField;
+			if (
+				select &&
+				!select.includes(requiredPhysical) &&
+				!select.includes(requiredSelectField)
+			) {
+				select.push(requiredPhysical);
 			}
 
 			const isUnique =

--- a/packages/experimental/test/adapter/schemas.ts
+++ b/packages/experimental/test/adapter/schemas.ts
@@ -1,0 +1,183 @@
+import { v } from "../../src";
+
+export const whereOperators = [
+	"eq",
+	"ne",
+	"lt",
+	"lte",
+	"gt",
+	"gte",
+	"in",
+	"not_in",
+	"contains",
+	"starts_with",
+	"ends_with",
+] as const;
+
+type WhereValue = string | number | boolean | string[] | number[] | Date | null;
+
+export const whereClause = v.object({
+	field: v.string(),
+	value: v.any<WhereValue>(),
+	operator: v.enum(whereOperators, { optional: true, default: "eq" }),
+	connector: v.enum(["AND", "OR"], { optional: true, default: "AND" }),
+	mode: v.enum(["sensitive", "insensitive"], {
+		optional: true,
+		default: "sensitive",
+	}),
+});
+
+export const cleanedWhere = v.object({
+	field: v.string(),
+	value: v.any<WhereValue>(),
+	operator: v.enum(whereOperators),
+	connector: v.enum(["AND", "OR"]),
+	mode: v.enum(["sensitive", "insensitive"]),
+});
+
+export const sortBySchema = v.object({
+	field: v.string(),
+	direction: v.enum(["asc", "desc"]),
+});
+
+export const adapterConfig = v.object({
+	adapterId: v.string({ optional: true, default: "memory" }),
+	adapterName: v.string({ optional: true }),
+	supportsNumericIds: v.boolean({ optional: true, default: true }),
+	supportsUUIDs: v.boolean({ optional: true, default: true }),
+	supportsJSON: v.boolean({ optional: true, default: false }),
+	supportsDates: v.boolean({ optional: true, default: true }),
+	supportsBooleans: v.boolean({ optional: true, default: true }),
+	supportsArrays: v.boolean({ optional: true, default: false }),
+	supportsJoins: v.boolean({ optional: true, default: false }),
+	/** When false, `db.transaction` runs the callback without begin/commit. */
+	supportsTransactions: v.boolean({ optional: true, default: true }),
+	disableIdGeneration: v.boolean({ optional: true, default: false }),
+	usePlural: v.boolean({ optional: true, default: false }),
+	defaultFindManyLimit: v.number({ optional: true, default: 100 }),
+});
+
+export const createInput = v.object({
+	model: v.string(),
+	data: v.record(v.any()),
+	select: v.array(v.string(), { optional: true }),
+});
+
+export const findOneInput = v.object({
+	model: v.string(),
+	where: v.array(whereClause),
+	select: v.array(v.string(), { optional: true }),
+	join: v.record(v.any(), { optional: true }),
+});
+
+export const findManyInput = v.object({
+	model: v.string(),
+	where: v.array(whereClause, { optional: true }),
+	limit: v.number({ optional: true }),
+	select: v.array(v.string(), { optional: true }),
+	sortBy: v.object(
+		{ field: v.string(), direction: v.enum(["asc", "desc"]) },
+		{ optional: true },
+	),
+	offset: v.number({ optional: true }),
+	join: v.record(v.any(), { optional: true }),
+});
+
+export const countInput = v.object({
+	model: v.string(),
+	where: v.array(whereClause, { optional: true }),
+});
+
+export const updateInput = v.object({
+	model: v.string(),
+	where: v.array(whereClause),
+	update: v.record(v.any()),
+});
+
+export const updateManyInput = v.object({
+	model: v.string(),
+	where: v.array(whereClause),
+	update: v.record(v.any()),
+});
+
+export const deleteInput = v.object({
+	model: v.string(),
+	where: v.array(whereClause),
+});
+
+export const consumeOneInput = v.object({
+	model: v.string(),
+	where: v.array(whereClause),
+});
+
+export const incrementOneInput = v.object({
+	model: v.string(),
+	where: v.array(whereClause),
+	increment: v.record(v.number()),
+	set: v.record(v.any(), { optional: true }),
+});
+
+export const applySchemaInput = v.object({
+	file: v.string({ optional: true }),
+	tables: v.record(v.any(), { optional: true }),
+});
+
+/** @deprecated Use `applySchemaInput`. */
+export const createSchemaInput = applySchemaInput;
+
+export const storageCreateInput = v.object({
+	model: v.string(),
+	data: v.record(v.any()),
+	select: v.array(v.string(), { optional: true }),
+});
+
+export const storageFindOneInput = v.object({
+	model: v.string(),
+	where: v.array(cleanedWhere),
+	select: v.array(v.string(), { optional: true }),
+});
+
+export const storageFindManyInput = v.object({
+	model: v.string(),
+	where: v.array(cleanedWhere, { optional: true }),
+	limit: v.number(),
+	select: v.array(v.string(), { optional: true }),
+	sortBy: v.object(
+		{ field: v.string(), direction: v.enum(["asc", "desc"]) },
+		{ optional: true },
+	),
+	offset: v.number({ optional: true }),
+});
+
+export const storageCountInput = v.object({
+	model: v.string(),
+	where: v.array(cleanedWhere, { optional: true }),
+});
+
+export const storageUpdateInput = v.object({
+	model: v.string(),
+	where: v.array(cleanedWhere),
+	update: v.record(v.any()),
+});
+
+export const storageDeleteInput = v.object({
+	model: v.string(),
+	where: v.array(cleanedWhere),
+});
+
+export const storageIncrementInput = v.object({
+	model: v.string(),
+	where: v.array(cleanedWhere),
+	increment: v.record(v.number()),
+	set: v.record(v.any(), { optional: true }),
+});
+
+export const storageApplyDDLInput = v.object({
+	statements: v.array(v.string()),
+	file: v.string({ optional: true }),
+});
+
+export const unsupportedError = v.object({
+	feature: v.string(),
+	message: v.string({ optional: true }),
+});

--- a/packages/experimental/test/adapter/sql.ts
+++ b/packages/experimental/test/adapter/sql.ts
@@ -1,0 +1,22 @@
+import { v } from "../../src";
+import { fieldAttribute } from "./field";
+
+export const modifiers = v.fn(
+	"sql.modifiers",
+	{ input: fieldAttribute },
+	(c) => {
+		const out: string[] = [];
+		if (c.input.unique) out.push("UNIQUE");
+		return out.join(" ").trim();
+	},
+);
+
+export const assemble = v.fn(
+	"sql.assemble",
+	{ input: [v.string(), fieldAttribute] },
+	(c) => {
+		const [type, attr] = c.input;
+		const mod = modifiers(attr);
+		return mod ? `${type} ${mod}` : type;
+	},
+);

--- a/packages/experimental/test/adapter/sqlite.test.ts
+++ b/packages/experimental/test/adapter/sqlite.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { ValidationError } from "../../src";
+import {
+	ddl,
+	generateColumn,
+	generateTable,
+	runMap,
+	sqliteTypes,
+} from "./index";
+
+describe("sqlite type generation", () => {
+	describe("runMap", () => {
+		it("maps string → varchar(255)", () => {
+			expect(runMap({ type: "string" })).toBe("varchar(255)");
+		});
+
+		it("appends UNIQUE when unique is set", () => {
+			expect(runMap({ type: "string", unique: true })).toBe(
+				"varchar(255) UNIQUE",
+			);
+		});
+
+		it("maps number → int(16)", () => {
+			expect(runMap({ type: "number" })).toBe("int(16)");
+		});
+
+		it("maps number + bigint → bigint", () => {
+			expect(runMap({ type: "number", bigint: true })).toBe("bigint");
+		});
+
+		it("maps number + bigint + unique", () => {
+			expect(runMap({ type: "number", bigint: true, unique: true })).toBe(
+				"bigint UNIQUE",
+			);
+		});
+
+		it("maps boolean → integer", () => {
+			expect(runMap({ type: "boolean" })).toBe("integer");
+		});
+
+		it("maps json → text", () => {
+			expect(runMap({ type: "json" })).toBe("text");
+		});
+
+		it("defaults type to string when omitted", () => {
+			expect(runMap({})).toBe("varchar(255)");
+		});
+
+		it("returns null for unmapped types", () => {
+			expect(runMap({ type: "uuid" })).toBeNull();
+		});
+
+		it("rejects invalid input", () => {
+			expect(() => runMap({ type: 1 } as never)).toThrow(ValidationError);
+		});
+	});
+
+	describe("sqlite mappers", () => {
+		it("string mapper ignores non-strings", () => {
+			expect(sqliteTypes.mapSqliteString({ type: "number" })).toBeNull();
+		});
+
+		it("number mapper ignores non-numbers", () => {
+			expect(sqliteTypes.mapSqliteNumber({ type: "string" })).toBeNull();
+		});
+	});
+
+	describe("generateColumn", () => {
+		it("names a mapped field", () => {
+			expect(
+				generateColumn({
+					name: "email",
+					field: { type: "string", unique: true },
+				}),
+			).toBe("email varchar(255) UNIQUE");
+		});
+
+		it("returns null when no mapper matches", () => {
+			expect(
+				generateColumn({ name: "meta", field: { type: "uuid" } }),
+			).toBeNull();
+		});
+	});
+
+	describe("generateTable", () => {
+		it("builds CREATE TABLE from many fields", () => {
+			expect(
+				generateTable({
+					name: "user",
+					fields: {
+						id: { type: "string", unique: true },
+						age: { type: "number" },
+						balance: { type: "number", bigint: true },
+					},
+				}),
+			).toBe(
+				"CREATE TABLE user (id varchar(255) UNIQUE, age int(16), balance bigint)",
+			);
+		});
+
+		it("throws when a field has no mapper", () => {
+			expect(() =>
+				generateTable({
+					name: "doc",
+					fields: {
+						id: { type: "string" },
+						payload: { type: "uuid" },
+					},
+				}),
+			).toThrow(/no type mapper for field "payload"/);
+		});
+
+		it("is available through ddl", () => {
+			const migrate = ddl.fn("test.migrate", (c) =>
+				c.use.generateTable({
+					name: "session",
+					fields: {
+						id: { type: "string", unique: true },
+						userId: { type: "string" },
+					},
+				}),
+			);
+			expect(migrate()).toBe(
+				"CREATE TABLE session (id varchar(255) UNIQUE, userId varchar(255))",
+			);
+		});
+	});
+});

--- a/packages/experimental/test/adapter/sqlite.ts
+++ b/packages/experimental/test/adapter/sqlite.ts
@@ -1,0 +1,394 @@
+import type { Database } from "bun:sqlite";
+import { v } from "../../src";
+import {
+	storageApplyDDLInput,
+	storageCountInput,
+	storageCreateInput,
+	storageDeleteInput,
+	storageFindManyInput,
+	storageFindOneInput,
+	storageIncrementInput,
+	storageUpdateInput,
+} from "./schemas";
+import type { CleanedWhere } from "./types";
+import { adapterVars } from "./vars";
+
+type Row = Record<string, any>;
+
+const storeUse = { use: [adapterVars] };
+
+const quoteIdent = (name: string) => `"${name.replaceAll('"', '""')}"`;
+
+const dbOf = (c: { var: { client: { get: () => unknown } } }): Database => {
+	const db = c.var.client.get() as Database | null;
+	if (!db) throw new Error("sqlite storage: client var is not set");
+	return db;
+};
+
+export const buildWhereSql = (where: CleanedWhere[] | undefined) => {
+	if (!where?.length) return { sql: "", params: [] as unknown[] };
+	const parts: string[] = [];
+	const params: unknown[] = [];
+	for (let i = 0; i < where.length; i++) {
+		const clause = where[i]!;
+		const col = quoteIdent(clause.field);
+		let fragment = "";
+		switch (clause.operator) {
+			case "eq":
+				fragment = `${col} = ?`;
+				params.push(clause.value);
+				break;
+			case "ne":
+				fragment = `${col} != ?`;
+				params.push(clause.value);
+				break;
+			case "lt":
+				fragment = `${col} < ?`;
+				params.push(clause.value);
+				break;
+			case "lte":
+				fragment = `${col} <= ?`;
+				params.push(clause.value);
+				break;
+			case "gt":
+				fragment = `${col} > ?`;
+				params.push(clause.value);
+				break;
+			case "gte":
+				fragment = `${col} >= ?`;
+				params.push(clause.value);
+				break;
+			case "in": {
+				const values = Array.isArray(clause.value) ? clause.value : [];
+				if (!values.length) {
+					fragment = "0 = 1";
+					break;
+				}
+				fragment = `${col} IN (${values.map(() => "?").join(", ")})`;
+				params.push(...values);
+				break;
+			}
+			case "not_in": {
+				const values = Array.isArray(clause.value) ? clause.value : [];
+				if (!values.length) {
+					fragment = "1 = 1";
+					break;
+				}
+				fragment = `${col} NOT IN (${values.map(() => "?").join(", ")})`;
+				params.push(...values);
+				break;
+			}
+			case "contains":
+				fragment =
+					clause.mode === "insensitive"
+						? `LOWER(${col}) LIKE ?`
+						: `${col} LIKE ?`;
+				params.push(
+					`%${clause.mode === "insensitive" ? String(clause.value).toLowerCase() : clause.value}%`,
+				);
+				break;
+			case "starts_with":
+				fragment =
+					clause.mode === "insensitive"
+						? `LOWER(${col}) LIKE ?`
+						: `${col} LIKE ?`;
+				params.push(
+					`${clause.mode === "insensitive" ? String(clause.value).toLowerCase() : clause.value}%`,
+				);
+				break;
+			case "ends_with":
+				fragment =
+					clause.mode === "insensitive"
+						? `LOWER(${col}) LIKE ?`
+						: `${col} LIKE ?`;
+				params.push(
+					`%${clause.mode === "insensitive" ? String(clause.value).toLowerCase() : clause.value}`,
+				);
+				break;
+			default:
+				fragment = `${col} = ?`;
+				params.push(clause.value);
+		}
+		if (i === 0) parts.push(fragment);
+		else parts.push(`${clause.connector} ${fragment}`);
+	}
+	return { sql: ` WHERE ${parts.join(" ")}`, params };
+};
+
+export const storageCreate = v.fn(
+	"storage.create",
+	{ input: storageCreateInput, ...storeUse },
+	(c) => {
+		const db = dbOf(c);
+		const data = c.input.data;
+		const keys = Object.keys(data);
+		const cols = keys.map(quoteIdent).join(", ");
+		const placeholders = keys.map(() => "?").join(", ");
+		db.run(
+			`INSERT INTO ${quoteIdent(c.input.model)} (${cols}) VALUES (${placeholders})`,
+			keys.map((k) => data[k] as any),
+		);
+		const id = data.id;
+		if (id != null) {
+			const row = db
+				.query(
+					`SELECT * FROM ${quoteIdent(c.input.model)} WHERE ${quoteIdent("id")} = ?`,
+				)
+				.get(id) as Row | null;
+			if (row) {
+				if (!c.input.select?.length) return row;
+				const out: Row = { id: row.id };
+				for (const s of c.input.select) out[s] = row[s];
+				return out;
+			}
+		}
+		return data;
+	},
+);
+
+export const storageFindOne = v.fn(
+	"storage.findOne",
+	{ input: storageFindOneInput, ...storeUse },
+	(c) => {
+		const db = dbOf(c);
+		const { sql, params } = buildWhereSql(c.input.where);
+		const row = db
+			.query(`SELECT * FROM ${quoteIdent(c.input.model)}${sql} LIMIT 1`)
+			.get(...params) as Row | null;
+		if (!row) return null;
+		if (!c.input.select?.length) return row;
+		const out: Row = {};
+		if ("id" in row) out.id = row.id;
+		for (const s of c.input.select) out[s] = row[s];
+		return out;
+	},
+);
+
+export const storageFindMany = v.fn(
+	"storage.findMany",
+	{ input: storageFindManyInput, ...storeUse },
+	(c) => {
+		const db = dbOf(c);
+		const { sql, params } = buildWhereSql(c.input.where);
+		let query = `SELECT * FROM ${quoteIdent(c.input.model)}${sql}`;
+		if (c.input.sortBy) {
+			query += ` ORDER BY ${quoteIdent(c.input.sortBy.field)} ${c.input.sortBy.direction.toUpperCase()}`;
+		}
+		query += ` LIMIT ?`;
+		params.push(c.input.limit);
+		if (c.input.offset) {
+			query += ` OFFSET ?`;
+			params.push(c.input.offset);
+		}
+		const rows = db.query(query).all(...params) as Row[];
+		if (!c.input.select?.length) return rows;
+		return rows.map((row) => {
+			const out: Row = {};
+			if ("id" in row) out.id = row.id;
+			for (const s of c.input.select!) out[s] = row[s];
+			return out;
+		});
+	},
+);
+
+export const storageCount = v.fn(
+	"storage.count",
+	{ input: storageCountInput, ...storeUse },
+	(c) => {
+		const db = dbOf(c);
+		const { sql, params } = buildWhereSql(c.input.where);
+		const row = db
+			.query(`SELECT COUNT(*) as count FROM ${quoteIdent(c.input.model)}${sql}`)
+			.get(...params) as { count: number };
+		return Number(row.count);
+	},
+);
+
+export const storageUpdate = v.fn(
+	"storage.update",
+	{ input: storageUpdateInput, ...storeUse },
+	(c) => {
+		const db = dbOf(c);
+		const keys = Object.keys(c.input.update);
+		const { sql, params } = buildWhereSql(c.input.where);
+		if (!keys.length) {
+			return (
+				(db
+					.query(`SELECT * FROM ${quoteIdent(c.input.model)}${sql} LIMIT 1`)
+					.get(...params) as Row | null) ?? null
+			);
+		}
+		const sets = keys.map((k) => `${quoteIdent(k)} = ?`).join(", ");
+		db.run(`UPDATE ${quoteIdent(c.input.model)} SET ${sets}${sql}`, [
+			...keys.map((k) => c.input.update[k]),
+			...params,
+		] as any);
+		return (
+			(db
+				.query(`SELECT * FROM ${quoteIdent(c.input.model)}${sql} LIMIT 1`)
+				.get(...params) as Row | null) ?? null
+		);
+	},
+);
+
+export const storageUpdateMany = v.fn(
+	"storage.updateMany",
+	{ input: storageUpdateInput, ...storeUse },
+	(c) => {
+		const db = dbOf(c);
+		const keys = Object.keys(c.input.update);
+		if (!keys.length) return 0;
+		const { sql, params } = buildWhereSql(c.input.where);
+		const sets = keys.map((k) => `${quoteIdent(k)} = ?`).join(", ");
+		const result = db.run(
+			`UPDATE ${quoteIdent(c.input.model)} SET ${sets}${sql}`,
+			[...keys.map((k) => c.input.update[k]), ...params] as any,
+		);
+		return result.changes;
+	},
+);
+
+export const storageDelete = v.fn(
+	"storage.delete",
+	{ input: storageDeleteInput, ...storeUse },
+	(c) => {
+		const db = dbOf(c);
+		const { sql, params } = buildWhereSql(c.input.where);
+		db.run(
+			`DELETE FROM ${quoteIdent(c.input.model)} WHERE rowid IN (SELECT rowid FROM ${quoteIdent(c.input.model)}${sql} LIMIT 1)`,
+			params as any,
+		);
+	},
+);
+
+export const storageDeleteMany = v.fn(
+	"storage.deleteMany",
+	{ input: storageDeleteInput, ...storeUse },
+	(c) => {
+		const db = dbOf(c);
+		const { sql, params } = buildWhereSql(c.input.where);
+		const result = db.run(
+			`DELETE FROM ${quoteIdent(c.input.model)}${sql}`,
+			params as any,
+		);
+		return result.changes;
+	},
+);
+
+/** Fallback consume via delete-returning pattern. */
+export const storageConsumeOne = v.fn(
+	"storage.consumeOne",
+	{ input: storageDeleteInput, ...storeUse },
+	(c) => {
+		const db = dbOf(c);
+		const { sql, params } = buildWhereSql(c.input.where);
+		const row = db
+			.query(`SELECT * FROM ${quoteIdent(c.input.model)}${sql} LIMIT 1`)
+			.get(...params) as Row | null;
+		if (!row) return null;
+		db.run(
+			`DELETE FROM ${quoteIdent(c.input.model)} WHERE rowid IN (SELECT rowid FROM ${quoteIdent(c.input.model)}${sql} LIMIT 1)`,
+			params as any,
+		);
+		return row;
+	},
+);
+
+export const storageIncrementOne = v.fn(
+	"storage.incrementOne",
+	{ input: storageIncrementInput, ...storeUse },
+	(c) => {
+		const db = dbOf(c);
+		const { sql, params } = buildWhereSql(c.input.where);
+		const row = db
+			.query(`SELECT * FROM ${quoteIdent(c.input.model)}${sql} LIMIT 1`)
+			.get(...params) as Row | null;
+		if (!row) return null;
+		const update: Record<string, unknown> = { ...(c.input.set ?? {}) };
+		for (const [field, delta] of Object.entries(c.input.increment)) {
+			update[field] = Number(row[field] ?? 0) + delta;
+		}
+		const keys = Object.keys(update);
+		const sets = keys.map((k) => `${quoteIdent(k)} = ?`).join(", ");
+		const id = row.id;
+		db.run(
+			`UPDATE ${quoteIdent(c.input.model)} SET ${sets} WHERE ${quoteIdent("id")} = ?`,
+			[...keys.map((k) => update[k]), id] as any,
+		);
+		return (
+			(db
+				.query(
+					`SELECT * FROM ${quoteIdent(c.input.model)} WHERE ${quoteIdent("id")} = ?`,
+				)
+				.get(id) as Row | null) ?? null
+		);
+	},
+);
+
+export const storageApplyDDL = v.fn(
+	"storage.applyDDL",
+	{ input: storageApplyDDLInput, ...storeUse },
+	(c) => {
+		const db = dbOf(c);
+		for (const statement of c.input.statements) {
+			db.run(statement);
+		}
+		return { applied: c.input.statements.length, file: c.input.file };
+	},
+);
+
+export const storageBegin = v.fn(
+	"storage.begin",
+	{ input: v.object({}), ...storeUse },
+	(c) => {
+		if (c.var.trx.get() != null) {
+			throw new Error("nested transactions are not supported");
+		}
+		dbOf(c).run("BEGIN");
+		c.var.trx.set({ active: true });
+		return { ok: true };
+	},
+);
+
+export const storageCommit = v.fn(
+	"storage.commit",
+	{ input: v.object({}), ...storeUse },
+	(c) => {
+		dbOf(c).run("COMMIT");
+		c.var.trx.set(null);
+		return { ok: true };
+	},
+);
+
+export const storageRollback = v.fn(
+	"storage.rollback",
+	{ input: v.object({}), ...storeUse },
+	(c) => {
+		try {
+			dbOf(c).run("ROLLBACK");
+		} catch {
+			/* no active transaction */
+		}
+		c.var.trx.set(null);
+		return { ok: true };
+	},
+);
+
+export const createSqliteStorage = (_db?: Database) => ({
+	storageCreate,
+	storageFindOne,
+	storageFindMany,
+	storageCount,
+	storageUpdate,
+	storageUpdateMany,
+	storageDelete,
+	storageDeleteMany,
+	storageConsumeOne,
+	storageIncrementOne,
+	storageApplyDDL,
+	storageBegin,
+	storageCommit,
+	storageRollback,
+});
+
+export const sqliteStorage = createSqliteStorage();

--- a/packages/experimental/test/adapter/to-module.ts
+++ b/packages/experimental/test/adapter/to-module.ts
@@ -1,0 +1,53 @@
+import { v } from "../../src";
+import type { DBAdapter } from "./types";
+
+/**
+ * @deprecated Prefer mounting `createBetterDB(...)` directly. Kept as a
+ * bridge from legacy `DBAdapter` objects to `v.fn` modules.
+ */
+export const toModule = (adapter: DBAdapter) => {
+	const create = v.fn("db.create", { input: v.object() }, (c) =>
+		adapter.create(c.input as any),
+	);
+	const findOne = v.fn("db.findOne", { input: v.object() }, (c) =>
+		adapter.findOne(c.input as any),
+	);
+	const findMany = v.fn("db.findMany", { input: v.object() }, (c) =>
+		adapter.findMany(c.input as any),
+	);
+	const count = v.fn("db.count", { input: v.object() }, (c) =>
+		adapter.count(c.input as any),
+	);
+	const update = v.fn("db.update", { input: v.object() }, (c) =>
+		adapter.update(c.input as any),
+	);
+	const updateMany = v.fn("db.updateMany", { input: v.object() }, (c) =>
+		adapter.updateMany(c.input as any),
+	);
+	const deleteOne = v.fn("db.delete", { input: v.object() }, (c) =>
+		adapter.delete(c.input as any),
+	);
+	const deleteMany = v.fn("db.deleteMany", { input: v.object() }, (c) =>
+		adapter.deleteMany(c.input as any),
+	);
+	const consumeOne = v.fn("db.consumeOne", { input: v.object() }, (c) =>
+		adapter.consumeOne(c.input as any),
+	);
+	const incrementOne = v.fn("db.incrementOne", { input: v.object() }, (c) =>
+		adapter.incrementOne(c.input as any),
+	);
+
+	return {
+		create,
+		findOne,
+		findMany,
+		count,
+		update,
+		updateMany,
+		delete: deleteOne,
+		deleteMany,
+		consumeOne,
+		incrementOne,
+		adapter,
+	};
+};

--- a/packages/experimental/test/adapter/types.ts
+++ b/packages/experimental/test/adapter/types.ts
@@ -1,0 +1,243 @@
+/** Better-auth-compatible DB adapter types (clean-room; no better-auth dep). */
+
+export type DBPrimitive =
+	| string
+	| number
+	| boolean
+	| Date
+	| null
+	| Record<string, unknown>
+	| unknown[];
+
+export type DBFieldType =
+	| "string"
+	| "number"
+	| "boolean"
+	| "date"
+	| "json"
+	| "string[]"
+	| "number[]";
+
+export type DBFieldAttribute = {
+	type: DBFieldType;
+	required?: boolean;
+	returned?: boolean;
+	input?: boolean;
+	unique?: boolean;
+	bigint?: boolean;
+	sortable?: boolean;
+	fieldName?: string;
+	defaultValue?: DBPrimitive | (() => DBPrimitive);
+	references?: {
+		model: string;
+		field: string;
+		onDelete?:
+			| "no action"
+			| "restrict"
+			| "cascade"
+			| "set null"
+			| "set default";
+	};
+};
+
+export type BetterAuthDBTable = {
+	modelName?: string;
+	fields: Record<string, DBFieldAttribute>;
+};
+
+export type BetterAuthDBSchema = Record<string, BetterAuthDBTable>;
+
+export const whereOperators = [
+	"eq",
+	"ne",
+	"lt",
+	"lte",
+	"gt",
+	"gte",
+	"in",
+	"not_in",
+	"contains",
+	"starts_with",
+	"ends_with",
+] as const;
+
+export type WhereOperator = (typeof whereOperators)[number];
+
+export type Where = {
+	field: string;
+	value: string | number | boolean | string[] | number[] | Date | null;
+	operator?: WhereOperator;
+	connector?: "AND" | "OR";
+	mode?: "sensitive" | "insensitive";
+};
+
+export type CleanedWhere = Required<
+	Pick<Where, "field" | "value" | "operator" | "connector">
+> & {
+	mode: "sensitive" | "insensitive";
+};
+
+export type JoinOption = {
+	[model: string]: boolean | { limit?: number };
+};
+
+export type JoinConfig = {
+	[model: string]: {
+		on: { from: string; to: string };
+		limit?: number;
+		relation?: "one-to-one" | "one-to-many" | "many-to-many";
+	};
+};
+
+export type SortBy = {
+	field: string;
+	direction: "asc" | "desc";
+};
+
+export type DBAdapterSchemaCreation = {
+	code: string;
+	path: string;
+	append?: boolean;
+	overwrite?: boolean;
+};
+
+export type DBTransactionAdapter = Omit<DBAdapter, "transaction">;
+
+export type DBAdapter = {
+	id: string;
+	create: <T extends Record<string, any> = Record<string, any>, R = T>(data: {
+		model: string;
+		data: Omit<T, "id"> & { id?: string };
+		select?: string[];
+	}) => Promise<R>;
+	findOne: <T = Record<string, any>>(data: {
+		model: string;
+		where: Where[];
+		select?: string[];
+		join?: JoinOption;
+	}) => Promise<T | null>;
+	findMany: <T = Record<string, any>>(data: {
+		model: string;
+		where?: Where[];
+		limit?: number;
+		select?: string[];
+		sortBy?: SortBy;
+		offset?: number;
+		join?: JoinOption;
+	}) => Promise<T[]>;
+	count: (data: { model: string; where?: Where[] }) => Promise<number>;
+	update: <T = Record<string, any>>(data: {
+		model: string;
+		where: Where[];
+		update: Record<string, any>;
+	}) => Promise<T | null>;
+	updateMany: (data: {
+		model: string;
+		where: Where[];
+		update: Record<string, any>;
+	}) => Promise<number>;
+	delete: (data: { model: string; where: Where[] }) => Promise<void>;
+	deleteMany: (data: { model: string; where: Where[] }) => Promise<number>;
+	consumeOne: <T = Record<string, any>>(data: {
+		model: string;
+		where: Where[];
+	}) => Promise<T | null>;
+	incrementOne: <T = Record<string, any>>(data: {
+		model: string;
+		where: Where[];
+		increment: Record<string, number>;
+		set?: Record<string, unknown>;
+	}) => Promise<T | null>;
+	transaction: <R>(
+		callback: (trx: DBTransactionAdapter) => Promise<R>,
+	) => Promise<R>;
+	applySchema?: (props: {
+		file?: string;
+		tables: BetterAuthDBSchema;
+	}) => Promise<DBAdapterSchemaCreation>;
+	/** @deprecated Use `applySchema`. */
+	createSchema?: (props: {
+		file?: string;
+		tables: BetterAuthDBSchema;
+	}) => Promise<DBAdapterSchemaCreation>;
+	options?: Record<string, any>;
+};
+
+export type CustomAdapter = {
+	create: <T extends Record<string, any>>(data: {
+		model: string;
+		data: T;
+		select?: string[];
+	}) => Promise<T>;
+	update: <T extends Record<string, any>>(data: {
+		model: string;
+		where: CleanedWhere[];
+		update: T;
+	}) => Promise<T | null>;
+	updateMany: (data: {
+		model: string;
+		where: CleanedWhere[];
+		update: Record<string, any>;
+	}) => Promise<number>;
+	findOne: <T = Record<string, any>>(data: {
+		model: string;
+		where: CleanedWhere[];
+		select?: string[];
+		join?: JoinConfig;
+	}) => Promise<T | null>;
+	findMany: <T = Record<string, any>>(data: {
+		model: string;
+		where?: CleanedWhere[];
+		limit: number;
+		select?: string[];
+		sortBy?: SortBy;
+		offset?: number;
+		join?: JoinConfig;
+	}) => Promise<T[]>;
+	delete: (data: { model: string; where: CleanedWhere[] }) => Promise<void>;
+	deleteMany: (data: {
+		model: string;
+		where: CleanedWhere[];
+	}) => Promise<number>;
+	count: (data: { model: string; where?: CleanedWhere[] }) => Promise<number>;
+	consumeOne?: <T = Record<string, any>>(data: {
+		model: string;
+		where: CleanedWhere[];
+	}) => Promise<T | null>;
+	incrementOne?: <T = Record<string, any>>(data: {
+		model: string;
+		where: CleanedWhere[];
+		increment: Record<string, number>;
+		set?: Record<string, unknown>;
+	}) => Promise<T | null>;
+	createSchema?: (props: {
+		file?: string;
+		tables: BetterAuthDBSchema;
+	}) => Promise<DBAdapterSchemaCreation>;
+	options?: Record<string, any>;
+};
+
+export type AdapterFactoryConfig = {
+	adapterId: string;
+	adapterName?: string;
+	supportsNumericIds?: boolean;
+	supportsUUIDs?: boolean;
+	supportsJSON?: boolean;
+	supportsDates?: boolean;
+	supportsBooleans?: boolean;
+	supportsArrays?: boolean;
+	supportsTransactions?:
+		| boolean
+		| ((
+				callback: (trx: DBTransactionAdapter) => Promise<unknown>,
+		  ) => Promise<unknown>);
+	disableIdGeneration?: boolean;
+	usePlural?: boolean;
+	/** @deprecated Use `supportsTransactions`. */
+	transaction?:
+		| false
+		| ((
+				callback: (trx: DBTransactionAdapter) => Promise<unknown>,
+		  ) => Promise<unknown>);
+	customIdGenerator?: (props: { model: string }) => string;
+};

--- a/packages/experimental/test/adapter/types/sqlite.ts
+++ b/packages/experimental/test/adapter/types/sqlite.ts
@@ -1,0 +1,70 @@
+import { v } from "../../../src";
+import { fieldAttribute } from "../field";
+import { assemble } from "../sql";
+
+const mapSqliteString = v.fn(
+	"sqlite.types.string",
+	{ input: fieldAttribute },
+	({ input: fieldAttr }) => {
+		if (fieldAttr.type !== "string") return null;
+		return assemble("varchar(255)", fieldAttr);
+	},
+);
+
+const mapSqliteNumber = v.fn(
+	"sqlite.types.number",
+	{ input: fieldAttribute },
+	({ input: fieldAttr }) => {
+		if (fieldAttr.type !== "number") return null;
+		if (fieldAttr.bigint) return assemble("bigint", fieldAttr);
+		return assemble("int(16)", fieldAttr);
+	},
+);
+
+const mapSqliteBoolean = v.fn(
+	"sqlite.types.boolean",
+	{ input: fieldAttribute },
+	({ input: fieldAttr }) => {
+		if (fieldAttr.type !== "boolean") return null;
+		return assemble("integer", fieldAttr);
+	},
+);
+
+const mapSqliteDate = v.fn(
+	"sqlite.types.date",
+	{ input: fieldAttribute },
+	({ input: fieldAttr }) => {
+		if (fieldAttr.type !== "date") return null;
+		return assemble("text", fieldAttr);
+	},
+);
+
+const mapSqliteJson = v.fn(
+	"sqlite.types.json",
+	{ input: fieldAttribute },
+	({ input: fieldAttr }) => {
+		if (
+			fieldAttr.type !== "json" &&
+			fieldAttr.type !== "string[]" &&
+			fieldAttr.type !== "number[]"
+		) {
+			return null;
+		}
+		return assemble("text", fieldAttr);
+	},
+);
+
+export const sqliteTypes = {
+	mapSqliteString,
+	mapSqliteNumber,
+	mapSqliteBoolean,
+	mapSqliteDate,
+	mapSqliteJson,
+	mappers: [
+		mapSqliteString,
+		mapSqliteNumber,
+		mapSqliteBoolean,
+		mapSqliteDate,
+		mapSqliteJson,
+	],
+};

--- a/packages/experimental/test/adapter/vars.ts
+++ b/packages/experimental/test/adapter/vars.ts
@@ -1,0 +1,43 @@
+import { v } from "../../src";
+import { dbSchema } from "./field";
+import { adapterConfig } from "./schemas";
+
+/** Logical Better Auth schema for the adapter tree. */
+export const schema = v.var("schema", {
+	default: {},
+	schema: dbSchema,
+});
+
+/** Adapter capability / naming flags (data only — no functions). */
+export const adapterConfigVar = v.var("adapterConfig", {
+	default: {
+		adapterId: "memory",
+		supportsJSON: false,
+		supportsDates: true,
+		supportsBooleans: true,
+		supportsJoins: false,
+		supportsTransactions: true,
+		defaultFindManyLimit: 100,
+	},
+	schema: adapterConfig,
+});
+
+/**
+ * Driver handle (sqlite Database, memory tables, …).
+ * Storage reads `trx` when set, otherwise `client`.
+ */
+export const client = v.var("client", {
+	default: null as object | null,
+});
+
+/** Active transaction handle / journal; null outside `db.transaction`. */
+export const trx = v.var("trx", {
+	default: null as object | null,
+});
+
+export const adapterVars = {
+	schema,
+	adapterConfig: adapterConfigVar,
+	client,
+	trx,
+};

--- a/packages/experimental/tsdown.config.ts
+++ b/packages/experimental/tsdown.config.ts
@@ -3,9 +3,7 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
 	entry: {
 		index: "src/index.ts",
-		client: "src/client.ts",
 		error: "src/error.ts",
-		node: "src/adapters/node/index.ts",
 	},
 	dts: { build: true, incremental: true },
 	sourcemap: true,


### PR DESCRIPTION
Add `v.array` / `v.record` / `v.enum` validation, rename accumulating vars from `v.record` to `v.merge`, type schema var handles with `InferArgs`, and land the adapter test suite against the updated schema surface.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>