### PR TITLE
chore: release v1.3.8

### DIFF
--- a/packages/better-call/package.json
+++ b/packages/better-call/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "better-call",
-	"version": "1.3.7",
+	"version": "1.3.8",
 	"type": "module",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Release `v1.3.8` (`1.3.7` → `1.3.8`).

### Bug Fixes

- include README in published package (#169) (8922d0b)

### CI

- **release**: use bumpp PR release flow (#173) (cbf66ef)
- **release**: restrict latest publishing to main (#172) (6edd284)

### Chores

- align Biome lint configuration (#164) (3a17814)
- **deps**: update project dependencies (#163) (4fecc36)
- add lefthook (#158) (cd3a2a2)
- upgrade TypeScript and tsdown (#156) (aa0644a)