### PR TITLE
chore: release v1.4.0

### DIFF
--- a/packages/better-call/package.json
+++ b/packages/better-call/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "better-call",
-	"version": "1.3.8",
+	"version": "1.4.0",
 	"type": "module",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Release `v1.4.0` (`1.3.8` → `1.4.0`).

### Breaking Changes

- **types**: align route params with rou3 and preserve endpoint type inference (#167) (f9e96da)

### CI

- **release**: resolve tag before generating notes (#175) (8e10fb3)