### PR TITLE
chore(experimental): export schema and read-only plugin

### DIFF
--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -52,6 +52,17 @@
 				"default": "./dist/error.cjs"
 			}
 		},
+		"./schema": {
+			"dev-source": "./src/schema.ts",
+			"import": {
+				"types": "./dist/schema.d.mts",
+				"default": "./dist/schema.mjs"
+			},
+			"require": {
+				"types": "./dist/schema.d.cts",
+				"default": "./dist/schema.cjs"
+			}
+		},
 		"./plugins/http": {
 			"dev-source": "./src/plugins/http.ts",
 			"import": {
@@ -61,6 +72,17 @@
 			"require": {
 				"types": "./dist/plugins/http.d.cts",
 				"default": "./dist/plugins/http.cjs"
+			}
+		},
+		"./plugins/read-only": {
+			"dev-source": "./src/plugins/read-only.ts",
+			"import": {
+				"types": "./dist/plugins/read-only.d.mts",
+				"default": "./dist/plugins/read-only.mjs"
+			},
+			"require": {
+				"types": "./dist/plugins/read-only.d.cts",
+				"default": "./dist/plugins/read-only.cjs"
 			}
 		}
 	},

--- a/packages/experimental/tsdown.config.ts
+++ b/packages/experimental/tsdown.config.ts
@@ -4,7 +4,9 @@ export default defineConfig({
 	entry: {
 		index: "src/index.ts",
 		error: "src/error.ts",
+		schema: "src/schema.ts",
 		"plugins/http": "src/plugins/http.ts",
+		"plugins/read-only": "src/plugins/read-only.ts",
 	},
 	dts: { build: true, incremental: true },
 	sourcemap: true,


### PR DESCRIPTION
## Summary

- Add `schema` and `plugins/read-only` as tsdown entry points so they land in the published dist
- Export `better-call/schema` and `better-call/plugins/read-only` from the package map for consumers

