### PR TITLE
fix(experimental): keep e.fn exports under declaration serialize limit

### DIFF
--- a/packages/experimental/src/declaration-emit.test.ts
+++ b/packages/experimental/src/declaration-emit.test.ts
@@ -1,0 +1,47 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const fixtureDir = join(root, "test/declaration-emit");
+
+/** Soft ceiling well under TS7056 (~1e6 chars). Pre-fix auth emits were
+ * ~750KB for two fns because ScopeOf/ResolvedVars inlined the module graph. */
+const MAX_DTS_BYTES = 80_000;
+
+describe("declaration emit (TS7056)", () => {
+	it("exports auth-sized e.fn results without ScopeOf graph expansion", () => {
+		const outDir = mkdtempSync(join(tmpdir(), "bc-decl-emit-"));
+		try {
+			execFileSync(
+				process.execPath,
+				[
+					join(root, "../../node_modules/typescript/bin/tsc"),
+					"-p",
+					join(fixtureDir, "tsconfig.json"),
+					"--outDir",
+					outDir,
+				],
+				{ cwd: root, stdio: "pipe" },
+			);
+
+			const dts = readFileSync(
+				join(outDir, "test/declaration-emit/auth-fns.d.ts"),
+				"utf8",
+			);
+			expect(dts.length).toBeLessThan(MAX_DTS_BYTES);
+			expect(dts).not.toMatch(/ScopeOf|ResolvedVars/);
+			expect(dts).not.toMatch(/\$models/);
+			expect(dts).toMatch(/export declare const signUpEmail:/);
+			expect(dts).toMatch(/export declare const signInEmail:/);
+			// Flat `.with` seeds: var leaves + bound creates, not module wrappers.
+			expect(dts).toMatch(/createUser\?:/);
+			expect(dts).toMatch(/user\?:/);
+		} finally {
+			rmSync(outDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/experimental/src/fn.ts
+++ b/packages/experimental/src/fn.ts
@@ -86,8 +86,53 @@ type WithFns<U> = {
  * (the builder's `use` included, not just the fn's own), plus any `use`
  * fn as an override - and nothing else. Kept as PLAIN mapped types: with
  * `RV`/`U` unknown both halves collapse to `{}`, which keeps every
- * `extends FnDefination<any, ...>` structural check passing. */
+ * `extends FnDefination<any, ...>` structural check passing.
+ *
+ * Prefer {@link WithSeed} for values stored on {@link FnDefination} - it
+ * is what `v.fn` returns, and stays declaration-emit safe. */
 export type WithContext<RV, U> = { [K in keyof RV]?: RV[K] } & WithFns<U>;
+
+/** Storage (or the FnEntries slice of one): anything carrying `$models`.
+ * Nested under a module as `{ db }`, it must not flow into `.with` seeds -
+ * model schemas alone blow past declaration serialize limits. ModuleFns
+ * drops `$adapter`/`$on`/collections, so duck-typing `$models` alone. */
+type StorageLike = { $models: object };
+
+/** Flatten `use` members to `.with` overrides: bound call signatures, var
+ * alias values, nested groups. Storage is dropped (mount-only). */
+type WithFnsSeed<U> = {
+	[K in keyof U as U[K] extends StorageLike
+		? never
+		: K]?: U[K] extends FnDefination<any, any, any, any, any, any>
+		? BoundFn<U[K]>
+		: U[K] extends VarDefination<any, infer T, any, any>
+			? T
+			: WithFnsSeed<U[K]>;
+};
+
+/**
+ * Flat `.with` seed map stored on exported fns. Evaluating ScopeOf /
+ * ModuleFns here (instead of embedding those wrappers as type arguments)
+ * keeps declaration emit small: `.d.ts` shows leaf var shapes and bound
+ * call signatures, not `ScopeOf<ResolvedVars<entire module graph>>`.
+ */
+export type WithSeed<RV, U> = Prettify<
+	{ [K in keyof RV]?: RV[K] } & WithFnsSeed<U>
+>;
+
+/** What `v.fn` / `e.fn` returns: contract params plus a flat {@link WithSeed}
+ * for `.with`, never the raw ScopeOf / ModuleFns graph. */
+type PublicFn<
+	A,
+	R,
+	K extends string,
+	I,
+	P extends readonly string[],
+	Er,
+	RV,
+	U,
+	O = unknown,
+> = FnDefination<A, R, K, I, P, Er, WithSeed<RV, U>, O>;
 
 /** What `.with` returns: the same callable, context baked in. */
 export interface BoundCall<A, R, I, Er> {
@@ -102,8 +147,9 @@ export interface FnDefination<
 	I = unknown,
 	P extends readonly string[] = readonly string[],
 	Er = NoErrors,
-	RV = unknown,
-	U = unknown,
+	/** `.with` seed map ({@link WithSeed}). Defaults keep structural
+	 * `extends FnDefination<any, ...>` checks passing. */
+	W = unknown,
 	O = unknown,
 > {
 	(...args: CallArgs<A, I>): R;
@@ -122,7 +168,7 @@ export interface FnDefination<
 	 * though `signOut` itself never says `use: [user]`. A parent passed to
 	 * the bound call is FORKED: its vars are copied in, never written back.
 	 */
-	with(context: WithContext<RV, U>): BoundCall<A, R, I, Er>;
+	with(context: W): BoundCall<A, R, I, Er>;
 	/** Brand, so a plugin module can be scanned for its fns. */
 	readonly $fn: true;
 	/** The name interceptors target - literal, so `ApplyOn` can match it. */
@@ -350,7 +396,7 @@ export interface Fn<
 				Fn<Base, BaseFns, BasePL, Prefix>
 			>,
 		) => R,
-	): FnDefination<
+	): PublicFn<
 		void,
 		R,
 		Prefix extends "" ? string : Prefix,
@@ -371,7 +417,7 @@ export interface Fn<
 				Fn<Base, BaseFns, BasePL, `${Prefix}${K}`>
 			>,
 		) => R,
-	): FnDefination<
+	): PublicFn<
 		void,
 		R,
 		`${Prefix}${K}`,
@@ -409,7 +455,7 @@ export interface Fn<
 				Er
 			>,
 		) => R,
-	): FnDefination<
+	): PublicFn<
 		ArgsOf<I>,
 		R,
 		Prefix extends "" ? string : Prefix,
@@ -449,7 +495,7 @@ export interface Fn<
 				Er
 			>,
 		) => R,
-	): FnDefination<
+	): PublicFn<
 		ArgsOf<I>,
 		R,
 		`${Prefix}${K}`,

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -99,6 +99,8 @@ export type {
 	OptionType,
 	ParentContext,
 	UseApi,
+	WithContext,
+	WithSeed,
 } from "./fn";
 export {
 	type ApplyOn,

--- a/packages/experimental/src/module.ts
+++ b/packages/experimental/src/module.ts
@@ -570,8 +570,8 @@ export type ApplyOn<F, PL> =
 		infer I,
 		infer P,
 		infer Er,
-		infer RV,
-		infer U
+		infer W,
+		infer O
 	>
 		? unknown extends ExtendedArgs<PL, K & string> & InputVarExtra<PL, I>
 			? F
@@ -586,8 +586,8 @@ export type ApplyOn<F, PL> =
 					I,
 					P,
 					Er,
-					RV,
-					U
+					W,
+					O
 				>
 		: F;
 

--- a/packages/experimental/test/declaration-emit/auth-fns.ts
+++ b/packages/experimental/test/declaration-emit/auth-fns.ts
@@ -1,0 +1,179 @@
+/**
+ * Auth-sized `use` graph (session + account + user + storage + extends).
+ * Declaration emit of these exports must stay under TS7056 - see
+ * `declaration-emit.test.ts`.
+ */
+import { memoryAdapter, v } from "../../src";
+
+const user = v.var("user", {
+	default: null,
+	schema: v.object({
+		id: v.string(),
+		name: v.string(),
+		email: v.string(),
+		emailVerified: v.boolean(),
+		image: v.string({ optional: true }),
+		createdAt: v.date(),
+		updatedAt: v.date(),
+	}),
+});
+
+const session = v.var("session", {
+	default: null,
+	schema: v.object({
+		id: v.string(),
+		userId: v.string(),
+		token: v.string(),
+		expiresAt: v.date(),
+		ipAddress: v.string({ optional: true }),
+		userAgent: v.string({ optional: true }),
+		createdAt: v.date(),
+		updatedAt: v.date(),
+	}),
+});
+
+const account = v.var("account", {
+	default: null,
+	schema: v.object({
+		id: v.string(),
+		userId: v.string(),
+		accountId: v.string(),
+		providerId: v.string(),
+		accessToken: v.string({ optional: true }),
+		refreshToken: v.string({ optional: true }),
+		accessTokenExpiresAt: v.date({ optional: true }),
+		refreshTokenExpiresAt: v.date({ optional: true }),
+		scope: v.string({ optional: true }),
+		idToken: v.string({ optional: true }),
+		password: v.string({ optional: true }),
+		createdAt: v.date(),
+		updatedAt: v.date(),
+	}),
+});
+
+const verification = v.var("verification", {
+	default: null,
+	schema: v.object({
+		id: v.string(),
+		identifier: v.string(),
+		value: v.string(),
+		expiresAt: v.date(),
+		createdAt: v.date({ optional: true }),
+		updatedAt: v.date({ optional: true }),
+	}),
+});
+
+const userWithEmail = v.extend(user, { email: v.string() });
+const accountWithPassword = v.extend(account, { password: v.string() });
+
+const db = v.storage(memoryAdapter(), {
+	user: {
+		schema: user,
+		fields: { email: { unique: true } },
+	},
+	session: { schema: session },
+	account: { schema: account },
+	verification: { schema: verification },
+});
+
+const coreUser = {
+	user,
+	createUser: v.fn(
+		"user.create",
+		{ use: [{ user }, db], input: user, provides: ["user"] as const },
+		async (c) => c.user,
+	),
+};
+
+const coreSession = {
+	session,
+	user,
+	createSession: v.fn(
+		"session.create",
+		{
+			use: [{ session, user }, db],
+			input: session,
+			provides: ["session"] as const,
+		},
+		async (c) => c.session,
+	),
+};
+
+const coreAccount = {
+	account,
+	createAccount: v.fn(
+		"account.create",
+		{
+			use: [{ account }, db],
+			input: account,
+			provides: ["account"] as const,
+		},
+		async (c) => c.account,
+	),
+};
+
+const e = v.fn("auth.", {
+	use: [
+		coreSession,
+		coreAccount,
+		coreUser,
+		{ accountWithPassword, userWithEmail, db },
+	],
+});
+
+export const signUpEmail = e.fn(
+	"sign_up.email",
+	{
+		input: {
+			email: v.string(),
+			password: v.string(),
+			name: v.string({ optional: true }),
+		},
+		errors: { user_already_exists: {} },
+		provides: ["user", "session"] as const,
+	},
+	async (c) => {
+		c.user = {
+			id: "1",
+			name: c.input.name ?? "x",
+			email: c.input.email,
+			emailVerified: false,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+		c.session = {
+			id: "s1",
+			userId: "1",
+			token: "t",
+			expiresAt: new Date(),
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+		return { user: c.user, session: c.session };
+	},
+);
+
+export const signInEmail = e.fn(
+	"sign_in.email",
+	{
+		input: { email: v.string(), password: v.string() },
+		errors: { invalid_credentials: {} },
+		provides: ["user", "session"] as const,
+	},
+	async (c) => {
+		const u = await db.user.findOne({ email: c.input.email } as {
+			email: string;
+		});
+		if (!u) throw c.error("invalid_credentials");
+		return { user: u };
+	},
+);
+
+// Call-site typing still works on the compact export surface.
+signUpEmail({ email: "a@b.c", password: "x" });
+signUpEmail.try({ email: "a@b.c", password: "x" });
+signUpEmail.with({ user: null });
+signInEmail.key satisfies "auth.sign_in.email";
+signUpEmail.provides satisfies readonly ["user", "session"];
+
+v.on(signUpEmail, async (_c, next) => next());

--- a/packages/experimental/test/declaration-emit/tsconfig.json
+++ b/packages/experimental/test/declaration-emit/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"outDir": "./out",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ESNext",
+		"skipLibCheck": true,
+		"lib": ["esnext", "dom"],
+		"types": ["node"],
+		"rootDir": "../.."
+	},
+	"include": ["./auth-fns.ts"]
+}


### PR DESCRIPTION
## Summary
- Exported `v.fn` / `e.fn` results now carry a flat `WithSeed` for `.with` instead of `ScopeOf` / `ModuleFns` type arguments, so auth-sized use graphs (session + account + user + storage + extends) no longer hit TS7056 on declaration emit.
- Storage nests are dropped from `.with` seeds (mount-only); handler `c` typing, call-site contracts, `.try`, `key`, `provides`, and `v.on` stay intact.
- Adds a declaration-emit fixture that would have failed before (~750KB `ScopeOf` expansion vs compact named/flat seeds).