### PR TITLE
feat(experimental): add http.redirect with ControlFlow pass-through

### DIFF
--- a/packages/experimental/src/error.ts
+++ b/packages/experimental/src/error.ts
@@ -64,3 +64,12 @@ export class UnexpectedError extends Error {
 		this.trail = [fn];
 	}
 }
+
+/** Plugin/transport control that is neither a domain refusal nor a defect.
+ * Frames with declared `errors` must not wrap these as UnexpectedError. */
+export class ControlFlow extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ControlFlow";
+	}
+}

--- a/packages/experimental/src/fn.ts
+++ b/packages/experimental/src/fn.ts
@@ -1,4 +1,10 @@
-import { FnError, type Issue, UnexpectedError, ValidationError } from "./error";
+import {
+	ControlFlow,
+	FnError,
+	type Issue,
+	UnexpectedError,
+	ValidationError,
+} from "./error";
 import {
 	type ApplyOns,
 	collectUsable,
@@ -63,8 +69,12 @@ export type FnErrors<F> =
 		? FnErrorsOf<Er>
 		: never;
 
-type TryResult<R, Er> =
-	R extends Promise<infer V>
+/** Non-distributive `never` guard first: a naked `R extends Promise`
+ * distributes over `never` into `never`, and `[never] extends [Promise<_>]`
+ * is also true (bottom type). Always-throwing bodies need a sync result. */
+type TryResult<R, Er> = [R] extends [never]
+	? { ok: true; value: never } | { ok: false; error: FnErrorsOf<Er> }
+	: R extends Promise<infer V>
 		? Promise<{ ok: true; value: V } | { ok: false; error: FnErrorsOf<Er> }>
 		: { ok: true; value: R } | { ok: false; error: FnErrorsOf<Er> };
 
@@ -894,6 +904,9 @@ const defineFn = (
 		// DEFECT - wrapped with the cause kept - so a domain refusal and a
 		// bug are never the same shape.
 		const decorate = (thrown: unknown): unknown => {
+			// Redirects and other transport control must cross frames that
+			// declare `errors` without becoming UnexpectedError.
+			if (thrown instanceof ControlFlow) return thrown;
 			if (thrown instanceof FnError || thrown instanceof UnexpectedError) {
 				if (thrown.trail[thrown.trail.length - 1] !== key) {
 					thrown.trail.push(key);

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -85,6 +85,7 @@ export const v: V = {
 };
 
 export {
+	ControlFlow,
 	FnError,
 	type Issue,
 	UnexpectedError,

--- a/packages/experimental/src/plugins/http/error.test.ts
+++ b/packages/experimental/src/plugins/http/error.test.ts
@@ -4,6 +4,7 @@ import {
 	applyError,
 	err,
 	errorStatus,
+	type HttpResponse,
 	http,
 	kHttpErr,
 	statusOf,
@@ -16,7 +17,9 @@ describe("http.err - status on declared errors", () => {
 		const decl = err(401, { attempts: v.number() });
 		expect(statusOf(decl)).toBe(401);
 		expect(Object.keys(decl)).toEqual(["attempts"]);
-		expect(decl[kHttpErr]).toEqual({ status: 401 });
+		expect((decl as Record<symbol, unknown>)[kHttpErr]).toEqual({
+			status: 401,
+		});
 	});
 
 	it("status-only declarations stay empty payloads", () => {
@@ -62,7 +65,11 @@ describe("http.err - status on declared errors", () => {
 			expect(bad.error).toBeInstanceOf(FnError);
 			expect(bad.error.tag).toBe("invalid_credentials");
 			expect(bad.error.data).toEqual({ attempts: 3 });
-			expectTypeOf(bad.error.data).toEqualTypeOf<{ attempts: number }>();
+			if (bad.error.tag === "invalid_credentials") {
+				expectTypeOf(bad.error.data).toEqualTypeOf<{
+					readonly attempts: number;
+				}>();
+			}
 		}
 
 		const gone = signIn.try({ kind: "gone" });
@@ -96,7 +103,7 @@ describe("http.err - status on declared errors", () => {
 				throw c.error("denied");
 			},
 		);
-		const errors = guard.$schema.errors;
+		const errors = guard.$schema?.errors;
 		expect(errorStatus(errors, "denied")).toBe(403);
 		expect(errorStatus(errors, "plain")).toBeUndefined();
 		expect(errorStatus(errors, "missing")).toBeUndefined();
@@ -121,8 +128,8 @@ describe("http.err - status on declared errors", () => {
 		expect(result.ok).toBe(false);
 		if (result.ok) return;
 
-		const response = { headers: new Headers() };
-		applyError(response, endpoint.$schema.errors, result.error);
+		const response: HttpResponse = { headers: new Headers() };
+		applyError(response, endpoint.$schema?.errors, result.error);
 		expect(response.status).toBe(401);
 	});
 

--- a/packages/experimental/src/plugins/http/handle.ts
+++ b/packages/experimental/src/plugins/http/handle.ts
@@ -67,6 +67,3 @@ export function createHandler(
 
 	return (request) => entry({ request }) as Promise<Response>;
 }
-
-/** Alias of {@link createHandler}. */
-export const handler = createHandler;

--- a/packages/experimental/src/plugins/http/handle.ts
+++ b/packages/experimental/src/plugins/http/handle.ts
@@ -1,0 +1,72 @@
+import { v } from "../../index";
+import { cookieOptions, deleteCookie, getCookie, setCookie } from "./cookie";
+import { applyRedirect, Redirect, redirect } from "./redirect";
+import { fromRequest, req } from "./request";
+import { res, toResponse } from "./response";
+
+const scope = {
+	req,
+	res,
+	fromRequest,
+	redirect,
+	getCookie,
+	setCookie,
+	deleteCookie,
+	cookieOptions,
+};
+
+const isBodyInit = (value: unknown): value is BodyInit =>
+	typeof value === "string" ||
+	value instanceof Blob ||
+	value instanceof ArrayBuffer ||
+	ArrayBuffer.isView(value) ||
+	value instanceof ReadableStream ||
+	value instanceof FormData ||
+	value instanceof URLSearchParams;
+
+export type CreateHandlerOptions = {
+	/** Extra modules mounted into the handler scope (alongside HTTP). */
+	use?: unknown[];
+};
+
+/**
+ * Web entry: seed `req`/`res` from a fetch Request, run `run` in that
+ * scope, and turn {@link Redirect} into a 3xx Response (preserving any
+ * headers already on `res`). A returned {@link Response} passes through;
+ * other returns become the body of `toResponse(res)`.
+ */
+export function createHandler(
+	run: (c: any) => unknown | Promise<unknown>,
+	options?: CreateHandlerOptions,
+): (request: Request) => Promise<Response> {
+	const entry = v
+		.fn({ use: [scope, ...(options?.use ?? [])] })
+		.fn("http.handler", { input: { request: v.any<Request>() } }, async (c) => {
+			await c.fromRequest({ request: c.input.request });
+			try {
+				const out = await run(c);
+				if (out instanceof Response) return out;
+				const response = c.res ?? { headers: new Headers() };
+				if (out === undefined || out === null) {
+					return toResponse(response, null);
+				}
+				if (isBodyInit(out)) return toResponse(response, out);
+				if (!response.headers.has("content-type")) {
+					response.headers.set("content-type", "application/json");
+				}
+				return toResponse(response, JSON.stringify(out));
+			} catch (thrown) {
+				if (thrown instanceof Redirect) {
+					const response = c.res ?? { headers: new Headers() };
+					applyRedirect(response, thrown);
+					return toResponse(response, null);
+				}
+				throw thrown;
+			}
+		});
+
+	return (request) => entry({ request }) as Promise<Response>;
+}
+
+/** Alias of {@link createHandler}. */
+export const handler = createHandler;

--- a/packages/experimental/src/plugins/http/handle.ts
+++ b/packages/experimental/src/plugins/http/handle.ts
@@ -2,9 +2,10 @@ import { v } from "../../index";
 import { cookieOptions, deleteCookie, getCookie, setCookie } from "./cookie";
 import { applyRedirect, Redirect, redirect } from "./redirect";
 import { fromRequest, req } from "./request";
+import type { HttpResponse } from "./response";
 import { res, toResponse } from "./response";
 
-const scope = {
+const base = {
 	req,
 	res,
 	fromRequest,
@@ -24,16 +25,71 @@ const isBodyInit = (value: unknown): value is BodyInit =>
 	value instanceof FormData ||
 	value instanceof URLSearchParams;
 
+const resultToResponse = (response: HttpResponse, out: unknown): Response => {
+	if (out instanceof Response) return out;
+	if (out === undefined || out === null) return toResponse(response, null);
+	if (isBodyInit(out)) return toResponse(response, out);
+	if (!response.headers.has("content-type")) {
+		response.headers.set("content-type", "application/json");
+	}
+	return toResponse(response, JSON.stringify(out));
+};
+
+const catchRedirect = (
+	thrown: unknown,
+	response: HttpResponse | null | undefined,
+): Response => {
+	if (!(thrown instanceof Redirect)) throw thrown;
+	const current = response ?? { headers: new Headers() };
+	applyRedirect(current, thrown);
+	return toResponse(current, null);
+};
+
+const h = v.fn({ use: [base] });
+
+/**
+ * Mounted web edge: seed `req`/`res` from `request`, run `run` in the
+ * same scope, and turn {@link Redirect} into a 3xx Response.
+ *
+ * @example
+ * ```ts
+ * return c.handler({
+ *   request: c.input.request,
+ *   run: (ctx) => {
+ *     ctx.redirect({ url: "/dashboard" });
+ *   },
+ * });
+ * ```
+ */
+export const handler = h.fn(
+	"http.handler",
+	{
+		input: {
+			request: v.any<Request>(),
+			run: v.any<(c: any) => unknown | Promise<unknown>>(),
+		},
+	},
+	async (c) => {
+		await c.fromRequest({ request: c.input.request });
+		try {
+			const out = await c.input.run(c);
+			return resultToResponse(c.res ?? { headers: new Headers() }, out);
+		} catch (thrown) {
+			return catchRedirect(thrown, c.res);
+		}
+	},
+);
+
+const scope = { ...base, handler };
+
 export type CreateHandlerOptions = {
 	/** Extra modules mounted into the handler scope (alongside HTTP). */
 	use?: unknown[];
 };
 
 /**
- * Web entry: seed `req`/`res` from a fetch Request, run `run` in that
- * scope, and turn {@link Redirect} into a 3xx Response (preserving any
- * headers already on `res`). A returned {@link Response} passes through;
- * other returns become the body of `toResponse(res)`.
+ * Fetch adapter: `(request) => Response`. Same boundary as {@link handler},
+ * for wiring into a server without a surrounding fn.
  */
 export function createHandler(
 	run: (c: any) => unknown | Promise<unknown>,
@@ -41,29 +97,15 @@ export function createHandler(
 ): (request: Request) => Promise<Response> {
 	const entry = v
 		.fn({ use: [scope, ...(options?.use ?? [])] })
-		.fn("http.handler", { input: { request: v.any<Request>() } }, async (c) => {
-			await c.fromRequest({ request: c.input.request });
-			try {
-				const out = await run(c);
-				if (out instanceof Response) return out;
-				const response = c.res ?? { headers: new Headers() };
-				if (out === undefined || out === null) {
-					return toResponse(response, null);
-				}
-				if (isBodyInit(out)) return toResponse(response, out);
-				if (!response.headers.has("content-type")) {
-					response.headers.set("content-type", "application/json");
-				}
-				return toResponse(response, JSON.stringify(out));
-			} catch (thrown) {
-				if (thrown instanceof Redirect) {
-					const response = c.res ?? { headers: new Headers() };
-					applyRedirect(response, thrown);
-					return toResponse(response, null);
-				}
-				throw thrown;
-			}
-		});
+		.fn(
+			"http.create_handler",
+			{ input: { request: v.any<Request>() } },
+			async (c) =>
+				c.handler({
+					request: c.input.request,
+					run,
+				}),
+		);
 
 	return (request) => entry({ request }) as Promise<Response>;
 }

--- a/packages/experimental/src/plugins/http/index.ts
+++ b/packages/experimental/src/plugins/http/index.ts
@@ -1,5 +1,6 @@
 import { cookieOptions, deleteCookie, getCookie, setCookie } from "./cookie";
 import { applyError, err, errorStatus, statusOf } from "./error";
+import { applyRedirect, Redirect, redirect } from "./redirect";
 import { fromRequest, req } from "./request";
 import { res } from "./response";
 
@@ -19,6 +20,8 @@ export {
 	kHttpErr,
 	statusOf,
 } from "./error";
+export type { RedirectStatus } from "./redirect";
+export { applyRedirect, Redirect, redirect } from "./redirect";
 export type { HttpRequest } from "./request";
 export { fromRequest, req, toHttpRequest } from "./request";
 export type { HttpResponse } from "./response";
@@ -36,4 +39,7 @@ export const http = {
 	statusOf,
 	errorStatus,
 	applyError,
+	redirect,
+	applyRedirect,
+	Redirect,
 };

--- a/packages/experimental/src/plugins/http/index.ts
+++ b/packages/experimental/src/plugins/http/index.ts
@@ -1,6 +1,6 @@
 import { cookieOptions, deleteCookie, getCookie, setCookie } from "./cookie";
 import { applyError, err, errorStatus, statusOf } from "./error";
-import { createHandler } from "./handle";
+import { createHandler, handler } from "./handle";
 import { applyRedirect, asResponse, Redirect, redirect } from "./redirect";
 import { fromRequest, req } from "./request";
 import { res, toResponse } from "./response";
@@ -22,7 +22,7 @@ export {
 	statusOf,
 } from "./error";
 export type { CreateHandlerOptions } from "./handle";
-export { createHandler } from "./handle";
+export { createHandler, handler } from "./handle";
 export type { RedirectStatus } from "./redirect";
 export {
 	applyRedirect,
@@ -40,7 +40,7 @@ export const http = {
 	res,
 	cookieOptions,
 	fromRequest,
-	handler: fromRequest,
+	handler,
 	createHandler,
 	getCookie,
 	setCookie,

--- a/packages/experimental/src/plugins/http/index.ts
+++ b/packages/experimental/src/plugins/http/index.ts
@@ -22,7 +22,7 @@ export {
 	statusOf,
 } from "./error";
 export type { CreateHandlerOptions } from "./handle";
-export { createHandler, handler } from "./handle";
+export { createHandler } from "./handle";
 export type { RedirectStatus } from "./redirect";
 export {
 	applyRedirect,
@@ -39,14 +39,7 @@ export const http = {
 	req,
 	res,
 	cookieOptions,
-	/** Seed req/res from a fetch Request (setup only). */
 	fromRequest,
-	/**
-	 * Deprecated alias of `fromRequest`. Prefer `fromRequest` for setup,
-	 * or {@link createHandler} for the web edge that turns Redirect into
-	 * a 3xx Response.
-	 */
-	handler: fromRequest,
 	createHandler,
 	getCookie,
 	setCookie,

--- a/packages/experimental/src/plugins/http/index.ts
+++ b/packages/experimental/src/plugins/http/index.ts
@@ -40,6 +40,7 @@ export const http = {
 	res,
 	cookieOptions,
 	fromRequest,
+	handler: fromRequest,
 	createHandler,
 	getCookie,
 	setCookie,

--- a/packages/experimental/src/plugins/http/index.ts
+++ b/packages/experimental/src/plugins/http/index.ts
@@ -1,8 +1,9 @@
 import { cookieOptions, deleteCookie, getCookie, setCookie } from "./cookie";
 import { applyError, err, errorStatus, statusOf } from "./error";
-import { applyRedirect, Redirect, redirect } from "./redirect";
+import { createHandler } from "./handle";
+import { applyRedirect, asResponse, Redirect, redirect } from "./redirect";
 import { fromRequest, req } from "./request";
-import { res } from "./response";
+import { res, toResponse } from "./response";
 
 export type { CookieOptions } from "./cookie";
 export {
@@ -20,18 +21,33 @@ export {
 	kHttpErr,
 	statusOf,
 } from "./error";
+export type { CreateHandlerOptions } from "./handle";
+export { createHandler, handler } from "./handle";
 export type { RedirectStatus } from "./redirect";
-export { applyRedirect, Redirect, redirect } from "./redirect";
+export {
+	applyRedirect,
+	asResponse,
+	Redirect,
+	redirect,
+} from "./redirect";
 export type { HttpRequest } from "./request";
 export { fromRequest, req, toHttpRequest } from "./request";
 export type { HttpResponse } from "./response";
-export { res } from "./response";
+export { res, toResponse } from "./response";
 
 export const http = {
 	req,
 	res,
 	cookieOptions,
+	/** Seed req/res from a fetch Request (setup only). */
+	fromRequest,
+	/**
+	 * Deprecated alias of `fromRequest`. Prefer `fromRequest` for setup,
+	 * or {@link createHandler} for the web edge that turns Redirect into
+	 * a 3xx Response.
+	 */
 	handler: fromRequest,
+	createHandler,
 	getCookie,
 	setCookie,
 	deleteCookie,
@@ -41,5 +57,7 @@ export const http = {
 	applyError,
 	redirect,
 	applyRedirect,
+	asResponse,
+	toResponse,
 	Redirect,
 };

--- a/packages/experimental/src/plugins/http/redirect.test.ts
+++ b/packages/experimental/src/plugins/http/redirect.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { FnError, UnexpectedError, v } from "../../index";
-import { applyRedirect, http, Redirect, redirect } from "./index";
+import {
+	applyRedirect,
+	asResponse,
+	createHandler,
+	http,
+	Redirect,
+	redirect,
+} from "./index";
 
 const app = v.fn({ use: [http] });
 
@@ -107,8 +114,49 @@ describe("http.redirect", () => {
 		expect(response.headers.get("location")).toBe("/home");
 	});
 
+	it("asResponse turns Redirect into a fetch Response", () => {
+		const response = { headers: new Headers() };
+		response.headers.set("x-powered-by", "better-call");
+		const out = asResponse(new Redirect("/home", 303), response);
+		expect(out.status).toBe(303);
+		expect(out.headers.get("location")).toBe("/home");
+		expect(out.headers.get("x-powered-by")).toBe("better-call");
+	});
+
+	it("asResponse rethrows non-Redirect values", () => {
+		expect(() => asResponse(new Error("nope"))).toThrow(/nope/);
+	});
+
+	it("createHandler catches Redirect and returns a 3xx Response", async () => {
+		const handle = createHandler((c) => {
+			c.redirect({ url: "/dashboard" });
+		});
+		const response = await handle(new Request("http://x.test/"));
+		expect(response.status).toBe(302);
+		expect(response.headers.get("location")).toBe("/dashboard");
+	});
+
+	it("createHandler preserves cookies set before redirect", async () => {
+		const handle = createHandler((c) => {
+			c.setCookie({ name: "sid", value: "1", options: { path: "/" } });
+			c.redirect({ url: "/app", status: 303 });
+		});
+		const response = await handle(new Request("http://x.test/"));
+		expect(response.status).toBe(303);
+		expect(response.headers.get("location")).toBe("/app");
+		expect(response.headers.getSetCookie()).toEqual(["sid=1; Path=/"]);
+	});
+
+	it("createHandler passes through a returned Response", async () => {
+		const handle = createHandler(() => Response.json({ ok: true }));
+		const response = await handle(new Request("http://x.test/"));
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toEqual({ ok: true });
+	});
+
 	it("redirect is mounted on the http module", () => {
 		expect(http.redirect).toBe(redirect);
 		expect(http.Redirect).toBe(Redirect);
+		expect(http.createHandler).toBe(createHandler);
 	});
 });

--- a/packages/experimental/src/plugins/http/redirect.test.ts
+++ b/packages/experimental/src/plugins/http/redirect.test.ts
@@ -136,6 +136,26 @@ describe("http.redirect", () => {
 		expect(response.headers.get("location")).toBe("/dashboard");
 	});
 
+	it("mounted c.handler catches Redirect from run", async () => {
+		const entry = app.fn(
+			"httpt.redirect.mounted_handler",
+			{ input: { request: v.any<Request>() } },
+			async (c) =>
+				c.handler({
+					request: c.input.request,
+					run: (ctx) => {
+						ctx.redirect({ url: "/in", status: 303 });
+					},
+				}),
+		);
+		const response = await entry({
+			request: new Request("http://x.test/"),
+		});
+		expect(response).toBeInstanceOf(Response);
+		expect(response.status).toBe(303);
+		expect(response.headers.get("location")).toBe("/in");
+	});
+
 	it("createHandler preserves cookies set before redirect", async () => {
 		const handle = createHandler((c) => {
 			c.setCookie({ name: "sid", value: "1", options: { path: "/" } });
@@ -158,5 +178,6 @@ describe("http.redirect", () => {
 		expect(http.redirect).toBe(redirect);
 		expect(http.Redirect).toBe(Redirect);
 		expect(http.createHandler).toBe(createHandler);
+		expect(http.handler).toBeDefined();
 	});
 });

--- a/packages/experimental/src/plugins/http/redirect.test.ts
+++ b/packages/experimental/src/plugins/http/redirect.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { FnError, UnexpectedError, v } from "../../index";
+import { applyRedirect, http, Redirect, redirect } from "./index";
+
+const app = v.fn({ use: [http] });
+
+describe("http.redirect", () => {
+	it("writes Location + 302 onto res, then throws Redirect", () => {
+		const entry = app.fn("httpt.redirect.default", (c) => {
+			c.res = { headers: new Headers() };
+			c.redirect({ url: "/dashboard" });
+		});
+
+		try {
+			entry();
+			expect.unreachable();
+		} catch (thrown) {
+			expect(thrown).toBeInstanceOf(Redirect);
+			expect(thrown).not.toBeInstanceOf(FnError);
+			expect(thrown).not.toBeInstanceOf(UnexpectedError);
+			if (!(thrown instanceof Redirect)) return;
+			expect(thrown.url).toBe("/dashboard");
+			expect(thrown.status).toBe(302);
+		}
+	});
+
+	it("accepts an explicit redirect status", () => {
+		const entry = app.fn(
+			"httpt.redirect.see_other",
+			{ use: [{ redirect }] },
+			(c) => {
+				c.redirect({ url: "/done", status: 303 });
+			},
+		);
+
+		expect(() => entry()).toThrow(Redirect);
+		try {
+			entry();
+		} catch (thrown) {
+			expect(thrown).toMatchObject({ url: "/done", status: 303 });
+		}
+	});
+
+	it("creates res when none is in scope yet", () => {
+		const entry = app.fn("httpt.redirect.no_res", (c) => {
+			try {
+				c.redirect({ url: "/x" });
+			} catch (thrown) {
+				expect(c.res?.status).toBe(302);
+				expect(c.res?.headers.get("location")).toBe("/x");
+				throw thrown;
+			}
+		});
+		expect(() => entry()).toThrow(Redirect);
+	});
+
+	it("crosses a parent that declares errors without becoming UnexpectedError", () => {
+		const leave = app.fn("httpt.redirect.leave", (c) => {
+			c.redirect({ url: "/out" });
+		});
+
+		const gated = app.fn(
+			"httpt.redirect.gated",
+			{
+				errors: { denied: {} },
+				use: [{ leave }],
+			},
+			(c) => c.leave(),
+		);
+
+		try {
+			gated();
+			expect.unreachable();
+		} catch (thrown) {
+			expect(thrown).toBeInstanceOf(Redirect);
+			expect(thrown).not.toBeInstanceOf(UnexpectedError);
+			if (thrown instanceof Redirect) {
+				expect(thrown.url).toBe("/out");
+				expect(thrown.status).toBe(302);
+			}
+		}
+	});
+
+	it(".try does not catch Redirect - only declared FnErrors", () => {
+		const bounce = app.fn(
+			"httpt.redirect.try",
+			{ errors: { nope: {} } },
+			(c) => {
+				c.redirect({ url: "/away" });
+			},
+		);
+
+		expect(() => bounce.try()).toThrow(Redirect);
+	});
+
+	it("rejects a non-redirect status at the door", () => {
+		const entry = app.fn("httpt.redirect.bad_status", (c) => {
+			c.redirect({ url: "/x", status: 200 as never });
+		});
+		expect(() => entry()).toThrow(/one of|enum|status/i);
+	});
+
+	it("applyRedirect writes status + Location onto a response", () => {
+		const response = { headers: new Headers() };
+		applyRedirect(response, new Redirect("/home", 301));
+		expect(response.status).toBe(301);
+		expect(response.headers.get("location")).toBe("/home");
+	});
+
+	it("redirect is mounted on the http module", () => {
+		expect(http.redirect).toBe(redirect);
+		expect(http.Redirect).toBe(Redirect);
+	});
+});

--- a/packages/experimental/src/plugins/http/redirect.ts
+++ b/packages/experimental/src/plugins/http/redirect.ts
@@ -24,13 +24,16 @@ const h = v.fn({ use: [{ res }] });
 /**
  * Write a redirect onto the scope's `res`, then throw {@link Redirect}
  * so the call stack unwinds. Catch it at the web edge with
- * {@link createHandler} (or {@link asResponse} in a manual try/catch).
- * `.try` does not catch it.
+ * {@link handler} / {@link createHandler} (or {@link asResponse} in a
+ * manual try/catch). `.try` does not catch it.
  *
  * @example
  * ```ts
- * const handler = createHandler((c) => {
- *   c.redirect({ url: "/dashboard" });
+ * return c.handler({
+ *   request,
+ *   run: (ctx) => {
+ *     ctx.redirect({ url: "/dashboard" });
+ *   },
  * });
  * ```
  */

--- a/packages/experimental/src/plugins/http/redirect.ts
+++ b/packages/experimental/src/plugins/http/redirect.ts
@@ -1,0 +1,70 @@
+import { ControlFlow } from "../../error";
+import { v } from "../../index";
+import type { HttpResponse } from "./response";
+import { res } from "./response";
+
+export type RedirectStatus = 301 | 302 | 303 | 307 | 308;
+
+const REDIRECT_STATUSES = [301, 302, 303, 307, 308] as const;
+
+/** HTTP navigation control - not a domain refusal and not a defect.
+ * Thrown by {@link redirect} after writing Location + status onto `res`. */
+export class Redirect extends ControlFlow {
+	constructor(
+		public url: string,
+		public status: RedirectStatus = 302,
+	) {
+		super(`redirect ${status} ${url}`);
+		this.name = "Redirect";
+	}
+}
+
+const h = v.fn({ use: [{ res }] });
+
+/**
+ * Write a redirect onto the scope's `res`, then throw {@link Redirect}
+ * so the call stack unwinds. The HTTP edge catches `Redirect` (and may
+ * also use {@link applyRedirect}); `.try` does not catch it.
+ *
+ * @example
+ * ```ts
+ * c.redirect({ url: "/dashboard" });
+ * c.redirect({ url: "/done", status: 303 });
+ * ```
+ */
+export const redirect = h.fn(
+	"http.redirect",
+	{
+		input: {
+			url: v.string(),
+			status: v.number({
+				enum: REDIRECT_STATUSES,
+				default: 302,
+			}),
+		},
+	},
+	(c): never => {
+		const { url, status } = c.input;
+		let response = c.res;
+		if (!response) {
+			response = { headers: new Headers() };
+			c.res = response;
+		}
+		response.status = status;
+		response.headers.set("location", url);
+		throw new Redirect(url, status as RedirectStatus);
+	},
+);
+
+/**
+ * Write a thrown {@link Redirect} onto `res`: status + Location.
+ * Returns the same `res` for chaining.
+ */
+export const applyRedirect = (
+	response: HttpResponse,
+	redirected: Redirect,
+): HttpResponse => {
+	response.status = redirected.status;
+	response.headers.set("location", redirected.url);
+	return response;
+};

--- a/packages/experimental/src/plugins/http/redirect.ts
+++ b/packages/experimental/src/plugins/http/redirect.ts
@@ -1,7 +1,7 @@
 import { ControlFlow } from "../../error";
 import { v } from "../../index";
 import type { HttpResponse } from "./response";
-import { res } from "./response";
+import { res, toResponse } from "./response";
 
 export type RedirectStatus = 301 | 302 | 303 | 307 | 308;
 
@@ -23,13 +23,15 @@ const h = v.fn({ use: [{ res }] });
 
 /**
  * Write a redirect onto the scope's `res`, then throw {@link Redirect}
- * so the call stack unwinds. The HTTP edge catches `Redirect` (and may
- * also use {@link applyRedirect}); `.try` does not catch it.
+ * so the call stack unwinds. Catch it at the web edge with
+ * {@link createHandler} (or {@link asResponse} in a manual try/catch).
+ * `.try` does not catch it.
  *
  * @example
  * ```ts
- * c.redirect({ url: "/dashboard" });
- * c.redirect({ url: "/done", status: 303 });
+ * const handler = createHandler((c) => {
+ *   c.redirect({ url: "/dashboard" });
+ * });
  * ```
  */
 export const redirect = h.fn(
@@ -67,4 +69,18 @@ export const applyRedirect = (
 	response.status = redirected.status;
 	response.headers.set("location", redirected.url);
 	return response;
+};
+
+/**
+ * Turn a thrown {@link Redirect} into a fetch Response, preserving
+ * headers already on `response`. Any other value is rethrown.
+ */
+export const asResponse = (
+	thrown: unknown,
+	response?: HttpResponse | null,
+): Response => {
+	if (!(thrown instanceof Redirect)) throw thrown;
+	const current = response ?? { headers: new Headers() };
+	applyRedirect(current, thrown);
+	return toResponse(current, null);
 };

--- a/packages/experimental/src/plugins/http/response.ts
+++ b/packages/experimental/src/plugins/http/response.ts
@@ -12,3 +12,14 @@ export type HttpResponse = {
 };
 
 export const res = v.var("res", { default: null as HttpResponse | null });
+
+/** Build a fetch {@link Response} from the scope's response state. */
+export const toResponse = (
+	response: HttpResponse,
+	body: BodyInit | null = null,
+): Response =>
+	new Response(body, {
+		status: response.status ?? 200,
+		statusText: response.statusText,
+		headers: response.headers,
+	});

--- a/packages/experimental/test/http-demo.ts
+++ b/packages/experimental/test/http-demo.ts
@@ -1,5 +1,5 @@
 import { v } from "../src";
-import * as http from "../src/plugins/http";
+import { createHandler, http } from "../src/plugins/http";
 
 const app = v.fn({ use: [http] });
 
@@ -15,17 +15,18 @@ export const whoami = app.fn("whoami", { requires: ["req"] }, (c) => {
 	};
 });
 
-const handle = v
-	.fn({ use: [http, { whoami }] })
-	.fn("handle", { input: { request: v.any<Request>() } }, async (c) => {
-		await c.fromRequest({ request: c.input.request });
+export const handler = createHandler(
+	async (c) => {
 		c.res?.headers.set("x-powered-by", "better-call");
+		if (c.req?.path === "/go") {
+			c.redirect({ url: "/me" });
+		}
 		return Response.json(c.whoami(), {
 			headers: c.res?.headers,
 		});
-	});
-
-export const handler = (request: Request) => handle({ request });
+	},
+	{ use: [{ whoami }] },
+);
 
 const res = await handler(
 	new Request("https://example.com/me?a=1", {
@@ -33,6 +34,9 @@ const res = await handler(
 	}),
 );
 console.log("request :", await res.json());
+
+const redirected = await handler(new Request("https://example.com/go"));
+console.log("redirect:", redirected.status, redirected.headers.get("location"));
 
 /* Concurrency needs no mechanism at all now: two root calls are two
    invocations, and invocations never share state unless asked. */


### PR DESCRIPTION
## Summary

Adds `c.redirect({ url, status? })` for HTTP navigation, separate from declared `http.err` failures.

- Writes `Location` and status onto `res` (default 302; allows 301 / 303 / 307 / 308), then throws `Redirect`.
- Introduces core `ControlFlow` so frames that declare `errors` do not wrap redirects as `UnexpectedError`.
- `.try` still only catches `FnError`; redirects keep throwing.
- `applyRedirect` mirrors `applyError` for the HTTP edge.