### PR TITLE
fix(experimental): type createHandler run context from options.use

### DIFF
--- a/packages/experimental/src/plugins/http/handle.ts
+++ b/packages/experimental/src/plugins/http/handle.ts
@@ -1,4 +1,7 @@
+import type { Context, Fn } from "../../fn";
 import { v } from "../../index";
+import type { ApplyOns, Module, ModuleFns } from "../../module";
+import type { ScopeOf } from "../../scope";
 import { cookieOptions, deleteCookie, getCookie, setCookie } from "./cookie";
 import { applyRedirect, Redirect, redirect } from "./redirect";
 import { fromRequest, req } from "./request";
@@ -15,6 +18,18 @@ const base = {
 	deleteCookie,
 	cookieOptions,
 };
+
+type EdgeModules<PL extends readonly Module[]> = readonly [typeof base, ...PL];
+
+/** Context `run` receives: HTTP base plus anything in `options.use`. */
+export type CreateHandlerContext<PL extends readonly Module[] = readonly []> =
+	Context<
+		{ request: Request },
+		ScopeOf<EdgeModules<PL>>,
+		never,
+		ApplyOns<ModuleFns<EdgeModules<PL>>, EdgeModules<PL>>,
+		Fn
+	>;
 
 const isBodyInit = (value: unknown): value is BodyInit =>
 	typeof value === "string" ||
@@ -87,9 +102,9 @@ export const handler = h.fn(
 	async (c) => settle(c, c.input.request, c.input.run),
 );
 
-export type CreateHandlerOptions = {
+export type CreateHandlerOptions<PL extends readonly Module[] = readonly []> = {
 	/** Extra modules mounted onto the same `c` that `run` receives. */
-	use?: unknown[];
+	use?: PL;
 };
 
 /**
@@ -97,12 +112,16 @@ export type CreateHandlerOptions = {
  * mounted on the same context as `req` / `res` / `redirect`, so
  * `createHandler((c) => c.whoami(), { use: [{ whoami }] })` works.
  */
-export function createHandler(
-	run: (c: any) => unknown | Promise<unknown>,
-	options?: CreateHandlerOptions,
+export function createHandler<
+	const PL extends readonly Module[] = readonly [],
+	R = unknown,
+>(
+	run: (c: CreateHandlerContext<PL>) => R | Promise<R>,
+	options?: CreateHandlerOptions<PL>,
 ): (request: Request) => Promise<Response> {
+	const use = [base, ...(options?.use ?? [])] as EdgeModules<PL>;
 	const entry = v
-		.fn({ use: [base, ...(options?.use ?? [])] })
+		.fn({ use })
 		.fn(
 			"http.create_handler",
 			{ input: { request: v.any<Request>() } },

--- a/packages/experimental/src/plugins/http/index.ts
+++ b/packages/experimental/src/plugins/http/index.ts
@@ -21,8 +21,9 @@ export {
 	kHttpErr,
 	statusOf,
 } from "./error";
-export type { CreateHandlerOptions } from "./handle";
+export type { CreateHandlerContext, CreateHandlerOptions } from "./handle";
 export { createHandler, handler } from "./handle";
+
 export type { RedirectStatus } from "./redirect";
 export {
 	applyRedirect,

--- a/packages/experimental/src/plugins/http/redirect.test.ts
+++ b/packages/experimental/src/plugins/http/redirect.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { FnError, UnexpectedError, v } from "../../index";
 import {
 	applyRedirect,
 	asResponse,
 	createHandler,
+	type HttpResponse,
 	http,
 	Redirect,
 	redirect,
@@ -108,14 +109,14 @@ describe("http.redirect", () => {
 	});
 
 	it("applyRedirect writes status + Location onto a response", () => {
-		const response = { headers: new Headers() };
+		const response: HttpResponse = { headers: new Headers() };
 		applyRedirect(response, new Redirect("/home", 301));
 		expect(response.status).toBe(301);
 		expect(response.headers.get("location")).toBe("/home");
 	});
 
 	it("asResponse turns Redirect into a fetch Response", () => {
-		const response = { headers: new Headers() };
+		const response: HttpResponse = { headers: new Headers() };
 		response.headers.set("x-powered-by", "better-call");
 		const out = asResponse(new Redirect("/home", 303), response);
 		expect(out.status).toBe(303);
@@ -178,9 +179,13 @@ describe("http.redirect", () => {
 		const whoami = app.fn("httpt.whoami_edge", { requires: ["req"] }, (c) => ({
 			path: c.req.path,
 		}));
-		const handle = createHandler((c) => c.whoami(), {
-			use: [{ whoami }],
-		});
+		const handle = createHandler(
+			(c) => {
+				expectTypeOf(c.whoami).toBeCallableWith();
+				return c.whoami();
+			},
+			{ use: [{ whoami }] },
+		);
 		const response = await handle(new Request("http://x.test/me"));
 		expect(response.status).toBe(200);
 		await expect(response.json()).resolves.toEqual({ path: "/me" });


### PR DESCRIPTION
## Summary

`createHandler`'s `run` callback took `c: any`, so mounted `options.use` modules were not reflected in types even though they share the same runtime context.

- Add `CreateHandlerContext<PL>` (HTTP base plus `options.use`) and generic `createHandler` / `CreateHandlerOptions` so `run`'s `c` infers used members.
- Export `CreateHandlerContext` from the HTTP plugin entry.
- Tighten redirect edge tests around `HttpResponse` and `expectTypeOf` for the mounted `whoami` case.