### PR TITLE
feat(experimental): configurable field attrs on schemas via plugins

### DIFF
--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -85,6 +85,17 @@
 				"default": "./dist/plugins/read-only.cjs"
 			}
 		},
+		"./plugins/db": {
+			"dev-source": "./src/plugins/db.ts",
+			"import": {
+				"types": "./dist/plugins/db.d.mts",
+				"default": "./dist/plugins/db.mjs"
+			},
+			"require": {
+				"types": "./dist/plugins/db.d.cts",
+				"default": "./dist/plugins/db.cjs"
+			}
+		},
 		"./capability": {
 			"dev-source": "./src/capability.ts",
 			"import": {

--- a/packages/experimental/src/attrs.test.ts
+++ b/packages/experimental/src/attrs.test.ts
@@ -44,4 +44,20 @@ describe("schema $attrs", () => {
 		// Field schema on the var is untouched.
 		expect(attrsOf(marked.schema)).toBeUndefined();
 	});
+
+	it("customize after withAttrs keeps whole-var attrs", () => {
+		const user = v.var("attr_user_customize", {
+			default: null,
+			schema: v.object({ id: v.string() }),
+		});
+		const marked = withAttrs(user, "http", { serverOnly: true });
+		const widened = marked.customize({
+			schema: (c) => c.add({ role: c.string() }),
+		});
+		expect(widened.$var).toBe(true);
+		expect(attrsOf(widened, "http")).toEqual({ serverOnly: true });
+		expect(
+			(widened.schema as { shape: Record<string, unknown> }).shape.role,
+		).toBeDefined();
+	});
 });

--- a/packages/experimental/src/attrs.test.ts
+++ b/packages/experimental/src/attrs.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { ValidationError } from "./error";
+import { v } from "./index";
+import { attrsOf, validate, withAttrs } from "./schema";
+
+describe("schema $attrs", () => {
+	it("withAttrs merges within a namespace and isolates namespaces", () => {
+		const base = v.string();
+		const once = withAttrs(base, "db", { unique: true });
+		const twice = withAttrs(once, "db", { index: true });
+		const both = withAttrs(twice, "http", { serverOnly: true });
+
+		expect(attrsOf(twice, "db")).toEqual({ unique: true, index: true });
+		expect(attrsOf(both, "http")).toEqual({ serverOnly: true });
+		expect(attrsOf(both)?.db).toEqual({ unique: true, index: true });
+		// Original untouched.
+		expect(attrsOf(base)).toBeUndefined();
+	});
+
+	it("asType preserves $attrs on a type def", () => {
+		const marked = withAttrs(v.number({ min: 1 }), "db", { unique: true });
+		expect(attrsOf(marked, "db")).toEqual({ unique: true });
+		expect(validate(marked, 2, "n")).toBe(2);
+	});
+
+	it("validate ignores $attrs", () => {
+		const email = withAttrs(v.string({ email: true }), "db", {
+			unique: true,
+		});
+		expect(validate(email, "a@b.c", "email")).toBe("a@b.c");
+		expect(() => validate(email, "nope", "email")).toThrow(ValidationError);
+	});
+});

--- a/packages/experimental/src/attrs.test.ts
+++ b/packages/experimental/src/attrs.test.ts
@@ -30,4 +30,18 @@ describe("schema $attrs", () => {
 		expect(validate(email, "a@b.c", "email")).toBe("a@b.c");
 		expect(() => validate(email, "nope", "email")).toThrow(ValidationError);
 	});
+
+	it("withAttrs on a var keeps $var identity", () => {
+		const user = v.var("attr_user", {
+			default: null,
+			schema: v.object({ id: v.string() }),
+		});
+		const marked = withAttrs(user, "http", { serverOnly: true });
+		expect(marked.$var).toBe(true);
+		expect(marked.name).toBe("attr_user");
+		expect(typeof marked.customize).toBe("function");
+		expect(attrsOf(marked, "http")).toEqual({ serverOnly: true });
+		// Field schema on the var is untouched.
+		expect(attrsOf(marked.schema)).toBeUndefined();
+	});
 });

--- a/packages/experimental/src/capability.test.ts
+++ b/packages/experimental/src/capability.test.ts
@@ -505,6 +505,46 @@ describe("serve", () => {
 			createAgent(transport, { attestation: forged }),
 		).rejects.toThrow(/attestation not signed by this server/);
 	});
+	it("wire rejects http.serverOnly fields; in-process still accepts them", async () => {
+		const { serverOnly } = await import("./plugins/http/attrs");
+		const { ValidationError } = await import("./error");
+
+		const createUser = v.fn(
+			"user.create",
+			{
+				input: {
+					email: v.string(),
+					role: serverOnly(v.string({ optional: true })),
+				},
+				use: [{ capability }],
+			},
+			async (c) => ({ email: c.input.email, role: c.input.role }),
+		);
+
+		const server = await serve(
+			{ createUser },
+			{
+				defaults: () => ["user.create"],
+				identify: () => null,
+			},
+		);
+		const transport: Transport = async (message) =>
+			server.exec(JSON.parse(JSON.stringify(message)) as never);
+
+		const agent = await createAgent(transport);
+		await expect(
+			agent.call("user.create", { email: "a@b.c", role: "admin" }),
+		).rejects.toThrow(ValidationError);
+
+		await expect(
+			agent.call("user.create", { email: "a@b.c" }),
+		).resolves.toEqual({ email: "a@b.c", role: undefined });
+
+		// Direct in-process call may pass server-only fields.
+		await expect(
+			createUser({ email: "x@y.z", role: "admin" }),
+		).resolves.toEqual({ email: "x@y.z", role: "admin" });
+	});
 });
 
 describe("the rule: every fn validates its caller", () => {

--- a/packages/experimental/src/capability.ts
+++ b/packages/experimental/src/capability.ts
@@ -1,4 +1,5 @@
 import { collectFns, type FnDefination, type Module, v } from "./index";
+import { rejectServerOnly } from "./plugins/http/attrs";
 
 const subtle = globalThis.crypto.subtle;
 
@@ -563,6 +564,12 @@ export const serve = async (
 				// which frame has no memory reference behind it.
 				const held = await spend(token);
 				c.capability = { ...held, entry: c.input.call };
+			}
+			// Wire edge: reject http.serverOnly fields before the target
+			// validates (object validate would otherwise strip them quietly).
+			const inputSchema = (target as FnDefination<any, any>).$schema?.input;
+			if (inputSchema !== undefined) {
+				rejectServerOnly(inputSchema, c.input.input, c.input.call);
 			}
 			return (target as (i: unknown, p: unknown) => unknown)(c.input.input, c);
 		},

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -125,6 +125,16 @@ export {
 	type VarSetContext,
 	type VarsFrom,
 } from "./module";
+export {
+	type AttrBag,
+	attrsOf,
+	type InferArgs,
+	type InferInput,
+	type InferOutput,
+	type InferType,
+	type TypeDefination,
+	withAttrs,
+} from "./schema";
 export type {
 	ResolvedVars,
 	ScopeOf,
@@ -137,9 +147,11 @@ export {
 	conditionsOf,
 	type FieldMeta,
 	type FindManyOptions,
+	fieldsFromSchema,
 	type ModelConfig,
 	matchesWhere,
 	memoryAdapter,
+	resolveModelFields,
 	type Storage,
 	type StorageAdapter,
 	type StorageApi,

--- a/packages/experimental/src/plugins/db.ts
+++ b/packages/experimental/src/plugins/db.ts
@@ -1,0 +1,22 @@
+import { withAttrs } from "../schema";
+import type { FieldMeta } from "../storage";
+
+/** Persistence: no two rows share this value. */
+export const unique = <S>(schema: S): S =>
+	withAttrs(schema, "db", { unique: true });
+
+/** Persistence: worth an index. */
+export const indexed = <S>(schema: S): S =>
+	withAttrs(schema, "db", { index: true });
+
+/** Persistence: foreign key to `model.field`. */
+export const references = <S>(
+	schema: S,
+	ref: NonNullable<FieldMeta["references"]>,
+): S => withAttrs(schema, "db", { references: ref });
+
+export const db = {
+	unique,
+	indexed,
+	references,
+};

--- a/packages/experimental/src/plugins/http/attrs.test.ts
+++ b/packages/experimental/src/plugins/http/attrs.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { ValidationError } from "../../error";
+import { v } from "../../index";
+import { asType, attrsOf, validate } from "../../schema";
+import {
+	clientSchema,
+	fromJsonBody,
+	rejectServerOnly,
+	serverOnly,
+	wireInput,
+} from "./attrs";
+
+describe("http field attrs", () => {
+	const shape = {
+		id: v.string(),
+		role: serverOnly(v.string()),
+		meta: v.object({
+			note: v.string(),
+			secret: serverOnly(v.string()),
+		}),
+	};
+
+	it("serverOnly writes $attrs.http", () => {
+		expect(attrsOf(serverOnly(v.string()), "http")).toEqual({
+			serverOnly: true,
+		});
+	});
+
+	it("clientSchema drops server-only fields nested", () => {
+		const projected = asType(clientSchema(v.object(shape)));
+		expect(Object.keys(projected.shape as object).sort()).toEqual([
+			"id",
+			"meta",
+		]);
+		const meta = asType((projected.shape as Record<string, unknown>).meta);
+		expect(Object.keys(meta.shape as object)).toEqual(["note"]);
+	});
+
+	it("rejectServerOnly fails when a server-only key is present", () => {
+		expect(() =>
+			rejectServerOnly(v.object(shape), {
+				id: "1",
+				role: "admin",
+			}),
+		).toThrow(ValidationError);
+		expect(() =>
+			rejectServerOnly(v.object(shape), {
+				id: "1",
+				meta: { note: "hi", secret: "x" },
+			}),
+		).toThrow(/server-only/);
+	});
+
+	it("wireInput accepts client fields and rejects smuggled server-only", () => {
+		expect(
+			wireInput(v.object(shape), {
+				id: "1",
+				meta: { note: "hi" },
+			}),
+		).toEqual({ id: "1", meta: { note: "hi" } });
+		expect(() =>
+			wireInput(v.object(shape), { id: "1", role: "admin" }),
+		).toThrow(ValidationError);
+	});
+
+	it("in-process validate still accepts server-only fields", () => {
+		expect(
+			validate(
+				asType(v.object(shape)),
+				{
+					id: "1",
+					role: "admin",
+					meta: { note: "n", secret: "s" },
+				},
+				"user",
+			),
+		).toEqual({
+			id: "1",
+			role: "admin",
+			meta: { note: "n", secret: "s" },
+		});
+	});
+
+	it("fromJsonBody runs wireInput on the request body", async () => {
+		const request = new Request("https://example.com", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ id: "1", meta: { note: "ok" } }),
+		});
+		await expect(fromJsonBody(request, v.object(shape))).resolves.toEqual({
+			id: "1",
+			meta: { note: "ok" },
+		});
+
+		const smuggle = new Request("https://example.com", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ id: "1", role: "admin" }),
+		});
+		await expect(fromJsonBody(smuggle, v.object(shape))).rejects.toThrow(
+			ValidationError,
+		);
+	});
+});

--- a/packages/experimental/src/plugins/http/attrs.ts
+++ b/packages/experimental/src/plugins/http/attrs.ts
@@ -1,0 +1,115 @@
+import { ValidationError } from "../../error";
+import {
+	asType,
+	attrsOf,
+	isVar,
+	typeOf,
+	validate,
+	withAttrs,
+} from "../../schema";
+
+/** Mark a field as unusable over the wire - HTTP / capability edges
+ * reject it if present; in-process callers may still pass it. */
+export const serverOnly = <S>(schema: S): S =>
+	withAttrs(schema, "http", { serverOnly: true });
+
+const isServerOnly = (schema: unknown) =>
+	attrsOf(schema, "http")?.serverOnly === true;
+
+/**
+ * Drop fields (and nested object keys) marked {@link serverOnly}. Used
+ * for OpenAPI / client contracts; {@link InferArgs} on the original
+ * schema stays the full shape.
+ */
+export const clientSchema = <S>(schema: S): S => {
+	if (isVar(schema)) {
+		const v = schema as { schema?: unknown };
+		return {
+			...(schema as object),
+			schema: v.schema === undefined ? undefined : clientSchema(v.schema as S),
+		} as S;
+	}
+	const def = asType(schema);
+	if (def.name === "object" && def.shape !== undefined) {
+		const shape: Record<string, unknown> = {};
+		for (const [key, child] of Object.entries(
+			def.shape as Record<string, unknown>,
+		)) {
+			if (isServerOnly(child)) continue;
+			shape[key] = clientSchema(child);
+		}
+		return { ...def, shape } as S;
+	}
+	if (def.name === "array" && def.shape !== undefined) {
+		return { ...def, shape: clientSchema(def.shape) } as S;
+	}
+	return schema;
+};
+
+/**
+ * Throw if any {@link serverOnly} field is present on `value` (own key).
+ * Object validation otherwise strips unknown keys, so this is what stops
+ * wire callers from smuggling server-only values.
+ */
+export const rejectServerOnly = (
+	schema: unknown,
+	value: unknown,
+	path = "input",
+): void => {
+	if (value === null || value === undefined) return;
+	const root = isVar(schema)
+		? ((schema as { schema?: unknown }).schema ?? {})
+		: schema;
+	const def = asType(root);
+	if (def.name === "object" && def.shape !== undefined) {
+		if (typeOf(value) !== "object") return;
+		const record = value as Record<string, unknown>;
+		for (const [key, child] of Object.entries(
+			def.shape as Record<string, unknown>,
+		)) {
+			if (isServerOnly(child) && Object.hasOwn(record, key)) {
+				throw new ValidationError(
+					`${path}.${key}`,
+					"server-only field is not allowed over the wire",
+				);
+			}
+			if (Object.hasOwn(record, key)) {
+				rejectServerOnly(child, record[key], `${path}.${key}`);
+			}
+		}
+		return;
+	}
+	if (def.name === "array" && def.shape !== undefined && Array.isArray(value)) {
+		for (let i = 0; i < value.length; i++) {
+			rejectServerOnly(def.shape, value[i], `${path}[${i}]`);
+		}
+	}
+};
+
+/**
+ * Wire-side input gate: reject smuggled server-only keys, then validate
+ * against {@link clientSchema}.
+ */
+export const wireInput = <S>(
+	schema: S,
+	value: unknown,
+	path = "input",
+): unknown => {
+	rejectServerOnly(schema, value, path);
+	return validate(asType(clientSchema(schema)), value, path);
+};
+
+/** Parse a JSON request body and run it through {@link wireInput}. */
+export const fromJsonBody = async <S>(
+	request: Request,
+	schema: S,
+	path = "body",
+): Promise<unknown> => {
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		throw new ValidationError(path, "expected a JSON body");
+	}
+	return wireInput(schema, body, path);
+};

--- a/packages/experimental/src/plugins/http/index.ts
+++ b/packages/experimental/src/plugins/http/index.ts
@@ -1,3 +1,10 @@
+import {
+	clientSchema,
+	fromJsonBody,
+	rejectServerOnly,
+	serverOnly,
+	wireInput,
+} from "./attrs";
 import { cookieOptions, deleteCookie, getCookie, setCookie } from "./cookie";
 import { applyError, err, errorStatus, statusOf } from "./error";
 import { createHandler, handler } from "./handle";
@@ -5,6 +12,13 @@ import { applyRedirect, asResponse, Redirect, redirect } from "./redirect";
 import { fromRequest, req } from "./request";
 import { res, toResponse } from "./response";
 
+export {
+	clientSchema,
+	fromJsonBody,
+	rejectServerOnly,
+	serverOnly,
+	wireInput,
+} from "./attrs";
 export type { CookieOptions } from "./cookie";
 export {
 	cookieOptions,
@@ -23,7 +37,6 @@ export {
 } from "./error";
 export type { CreateHandlerContext, CreateHandlerOptions } from "./handle";
 export { createHandler, handler } from "./handle";
-
 export type { RedirectStatus } from "./redirect";
 export {
 	applyRedirect,
@@ -55,4 +68,9 @@ export const http = {
 	asResponse,
 	toResponse,
 	Redirect,
+	serverOnly,
+	clientSchema,
+	rejectServerOnly,
+	wireInput,
+	fromJsonBody,
 };

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -318,14 +318,31 @@ export const asType = (value: any): TypeDefination<any, any> =>
 
 /**
  * Attach plugin attributes under `namespace`, deep-merging with any
- * already on the schema. Returns a new type def; the value type is
- * unchanged. Core never reads these - only plugin edges do.
+ * already on the schema. Returns a new type def (or var) with the same
+ * value type. Core never reads these - only plugin edges do.
+ *
+ * Passed a var, attributes land on the var itself (`$attrs`) and the
+ * `$var` / `name` / `schema` / `customize` identity is preserved.
  */
 export const withAttrs = <S>(
 	schema: S,
 	namespace: string,
 	attrs: Record<string, unknown>,
 ): S => {
+	if (isVar(schema)) {
+		const v = schema as {
+			$attrs?: AttrBag;
+			[key: string]: unknown;
+		};
+		const prev = v.$attrs ?? {};
+		return {
+			...v,
+			$attrs: {
+				...prev,
+				[namespace]: { ...(prev[namespace] ?? {}), ...attrs },
+			},
+		} as S;
+	}
 	const def = asType(schema);
 	const prev = def.$attrs ?? {};
 	return {
@@ -348,7 +365,12 @@ export function attrsOf(
 	namespace?: string,
 ): AttrBag | Record<string, unknown> | undefined {
 	if (schema === null || schema === undefined) return undefined;
-	const bag = asType(schema).$attrs;
+	// Vars carry whole-var attrs on themselves; field attrs live on the
+	// schema type def. Do not unwrap through asType or var identity is
+	// lost and whole-var attrs become invisible.
+	const bag = isVar(schema)
+		? (schema as { $attrs?: AttrBag }).$attrs
+		: asType(schema).$attrs;
 	if (!bag) return undefined;
 	return namespace === undefined ? bag : bag[namespace];
 }

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -21,6 +21,10 @@ export type Rules = {
 	check?: (value: any) => boolean | string;
 };
 
+/** Plugin-owned field metadata. Outer key is the plugin namespace
+ * (`"http"`, `"db"`, …); core never interprets the contents. */
+export type AttrBag = Record<string, Record<string, unknown>>;
+
 export interface TypeDefination<T, O, D = never> extends Rules {
 	name: LiteralString;
 	type?: T;
@@ -34,6 +38,8 @@ export interface TypeDefination<T, O, D = never> extends Rules {
 	/** When true, `undefined` passes straight through unvalidated. */
 	optional?: boolean;
 	transform?: (value: any) => O;
+	/** Opaque plugin attributes - ignored by validate / Infer*. */
+	$attrs?: AttrBag;
 }
 
 export type TypeOptions<T, O> = {
@@ -309,6 +315,43 @@ export const asType = (value: any): TypeDefination<any, any> =>
 			: isType(value)
 				? value
 				: { name: "object", shape: value };
+
+/**
+ * Attach plugin attributes under `namespace`, deep-merging with any
+ * already on the schema. Returns a new type def; the value type is
+ * unchanged. Core never reads these - only plugin edges do.
+ */
+export const withAttrs = <S>(
+	schema: S,
+	namespace: string,
+	attrs: Record<string, unknown>,
+): S => {
+	const def = asType(schema);
+	const prev = def.$attrs ?? {};
+	return {
+		...def,
+		$attrs: {
+			...prev,
+			[namespace]: { ...(prev[namespace] ?? {}), ...attrs },
+		},
+	} as S;
+};
+
+/** Read the whole attr bag, or one plugin namespace. */
+export function attrsOf(schema: unknown): AttrBag | undefined;
+export function attrsOf(
+	schema: unknown,
+	namespace: string,
+): Record<string, unknown> | undefined;
+export function attrsOf(
+	schema: unknown,
+	namespace?: string,
+): AttrBag | Record<string, unknown> | undefined {
+	if (schema === null || schema === undefined) return undefined;
+	const bag = asType(schema).$attrs;
+	if (!bag) return undefined;
+	return namespace === undefined ? bag : bag[namespace];
+}
 
 export const typeOf = (value: unknown) =>
 	value === null

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -317,41 +317,45 @@ export const asType = (value: any): TypeDefination<any, any> =>
 				: { name: "object", shape: value };
 
 /**
+ * Replace the whole `$attrs` bag. On a var, rebinds `customize` so a later
+ * customize keeps these attrs (the original closure closes over pre-attr
+ * options and would otherwise drop them).
+ */
+const withAttrBag = <S>(schema: S, bag: AttrBag): S => {
+	if (isVar(schema)) {
+		const v = schema as {
+			$attrs?: AttrBag;
+			customize: (opts: any) => unknown;
+			[key: string]: unknown;
+		};
+		return {
+			...v,
+			$attrs: bag,
+			customize: (opts: any) => withAttrBag(v.customize(opts) as S, bag),
+		} as S;
+	}
+	return { ...asType(schema), $attrs: bag } as S;
+};
+
+/**
  * Attach plugin attributes under `namespace`, deep-merging with any
  * already on the schema. Returns a new type def (or var) with the same
  * value type. Core never reads these - only plugin edges do.
  *
  * Passed a var, attributes land on the var itself (`$attrs`) and the
- * `$var` / `name` / `schema` / `customize` identity is preserved.
+ * `$var` / `name` / `schema` identity is preserved; `customize` is rebound
+ * so attrs survive further customization.
  */
 export const withAttrs = <S>(
 	schema: S,
 	namespace: string,
 	attrs: Record<string, unknown>,
 ): S => {
-	if (isVar(schema)) {
-		const v = schema as {
-			$attrs?: AttrBag;
-			[key: string]: unknown;
-		};
-		const prev = v.$attrs ?? {};
-		return {
-			...v,
-			$attrs: {
-				...prev,
-				[namespace]: { ...(prev[namespace] ?? {}), ...attrs },
-			},
-		} as S;
-	}
-	const def = asType(schema);
-	const prev = def.$attrs ?? {};
-	return {
-		...def,
-		$attrs: {
-			...prev,
-			[namespace]: { ...(prev[namespace] ?? {}), ...attrs },
-		},
-	} as S;
+	const prev = (attrsOf(schema) ?? {}) as AttrBag;
+	return withAttrBag(schema, {
+		...prev,
+		[namespace]: { ...(prev[namespace] ?? {}), ...attrs },
+	});
 };
 
 /** Read the whole attr bag, or one plugin namespace. */

--- a/packages/experimental/src/storage.test.ts
+++ b/packages/experimental/src/storage.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { memoryAdapter, type StorageAdapter, v } from "./index";
+import {
+	memoryAdapter,
+	resolveModelFields,
+	type StorageAdapter,
+	v,
+} from "./index";
 import { db, indexed, references, unique } from "./plugins/db";
 
 describe("v.storage", () => {
@@ -417,7 +422,7 @@ describe("v.storage", () => {
 		).toEqual({ unique: false });
 	});
 
-	it("bare var with db attrs is wrapped so $models exposes fields", () => {
+	it("bare var stays a var on $models; resolveModelFields reads attrs", () => {
 		const item = v.var("stg_bare_attr", {
 			default: null,
 			schema: v.object({
@@ -427,11 +432,14 @@ describe("v.storage", () => {
 		});
 		const store = v.storage(memoryAdapter(), { item });
 		const model = store.$models.item as {
-			schema?: unknown;
-			fields?: Record<string, unknown>;
+			$var?: boolean;
+			name?: string;
 		};
-		expect(model.fields?.slug).toEqual({ unique: true });
-		expect((model.schema as { name: string }).name).toBe("stg_bare_attr");
+		expect(model.$var).toBe(true);
+		expect(model.name).toBe("stg_bare_attr");
+		expect(resolveModelFields(store.$models.item)?.slug).toEqual({
+			unique: true,
+		});
 	});
 
 	it("indexed and references wrappers write $attrs.db", () => {

--- a/packages/experimental/src/storage.test.ts
+++ b/packages/experimental/src/storage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { memoryAdapter, type StorageAdapter, v } from "./index";
+import { db, indexed, references, unique } from "./plugins/db";
 
 describe("v.storage", () => {
 	it("many instances of a var: CRUD in the var's shape", async () => {
@@ -379,6 +380,73 @@ describe("v.storage", () => {
 		});
 		const config = db.$models.item as { fields?: Record<string, unknown> };
 		expect(config.fields?.email).toEqual({ unique: true, index: true });
+	});
+
+	it("db attrs on the schema surface through $models; fields: overrides", () => {
+		const item = v.var("stg_attr_meta", {
+			default: null,
+			schema: v.object({
+				id: v.string(),
+				email: db.unique(db.indexed(v.string())),
+				ownerId: db.references(v.string(), {
+					model: "owner",
+					field: "id",
+				}),
+			}),
+		});
+		const fromSchema = v.storage(memoryAdapter(), {
+			item: { schema: item },
+		});
+		const fields = (
+			fromSchema.$models.item as { fields?: Record<string, unknown> }
+		).fields;
+		expect(fields?.email).toEqual({ unique: true, index: true });
+		expect(fields?.ownerId).toEqual({
+			references: { model: "owner", field: "id" },
+		});
+
+		const overridden = v.storage(memoryAdapter(), {
+			item: {
+				schema: item,
+				fields: { email: { unique: false } },
+			},
+		});
+		expect(
+			(overridden.$models.item as { fields?: Record<string, unknown> }).fields
+				?.email,
+		).toEqual({ unique: false });
+	});
+
+	it("bare var with db attrs is wrapped so $models exposes fields", () => {
+		const item = v.var("stg_bare_attr", {
+			default: null,
+			schema: v.object({
+				id: v.string(),
+				slug: unique(v.string()),
+			}),
+		});
+		const store = v.storage(memoryAdapter(), { item });
+		const model = store.$models.item as {
+			schema?: unknown;
+			fields?: Record<string, unknown>;
+		};
+		expect(model.fields?.slug).toEqual({ unique: true });
+		expect((model.schema as { name: string }).name).toBe("stg_bare_attr");
+	});
+
+	it("indexed and references wrappers write $attrs.db", () => {
+		expect(indexed(v.string())).toMatchObject({
+			$attrs: { db: { index: true } },
+		});
+		expect(
+			references(v.string(), { model: "u", field: "id", onDelete: "cascade" }),
+		).toMatchObject({
+			$attrs: {
+				db: {
+					references: { model: "u", field: "id", onDelete: "cascade" },
+				},
+			},
+		});
 	});
 
 	it("adapters are addressed by the VAR name, not the export key", async () => {

--- a/packages/experimental/src/storage.ts
+++ b/packages/experimental/src/storage.ts
@@ -1,5 +1,5 @@
 import { matchesTarget, type OnEntry } from "./module";
-import { isVar } from "./schema";
+import { asType, attrsOf, isVar } from "./schema";
 import type { ValueOfVar, VarDefination } from "./var";
 
 /* ---------------------------------- where ---------------------------------- */
@@ -282,7 +282,9 @@ type AnyVar = VarDefination<any, any, any, any>;
 
 /** Persistence facts about one field the ROW SHAPE can't say - consumed by
  * schema generators and adapters, never acted on by the runtime. (Read
- * shaping like redaction is a `$on` hook, not metadata.) */
+ * shaping like redaction is a `$on` hook, not metadata.) Prefer declaring
+ * these via `db.unique` / `db.indexed` / `db.references` on the field
+ * schema; `ModelConfig.fields` remains an override. */
 export type FieldMeta = {
 	/** No two rows share a value. */
 	unique?: boolean;
@@ -294,6 +296,57 @@ export type FieldMeta = {
 		field: string;
 		onDelete?: "cascade" | "set null" | "restrict";
 	};
+};
+
+/** Read `$attrs.db` off each field of a var's object schema. */
+export const fieldsFromSchema = (sv: AnyVar): Record<string, FieldMeta> => {
+	const schema = asType((sv as { schema?: unknown }).schema ?? {});
+	if (schema.name !== "object" || schema.shape === undefined) return {};
+	const fields: Record<string, FieldMeta> = {};
+	for (const [key, child] of Object.entries(
+		schema.shape as Record<string, unknown>,
+	)) {
+		const meta = attrsOf(child, "db") as FieldMeta | undefined;
+		if (meta && Object.keys(meta).length > 0) fields[key] = { ...meta };
+	}
+	return fields;
+};
+
+/**
+ * Schema attrs first; `ModelConfig.fields[k]` replaces that key entirely
+ * when present (compat override).
+ */
+export const resolveModelFields = (
+	input: ModelInput,
+): Record<string, FieldMeta> | undefined => {
+	if (isVar(input)) {
+		const fromSchema = fieldsFromSchema(input as AnyVar);
+		return Object.keys(fromSchema).length > 0 ? fromSchema : undefined;
+	}
+	const config = input as ModelConfig;
+	const fromSchema = fieldsFromSchema(config.schema);
+	const override = config.fields ?? {};
+	const merged: Record<string, FieldMeta> = { ...fromSchema };
+	for (const [key, meta] of Object.entries(override)) {
+		if (meta !== undefined) merged[key] = meta;
+	}
+	return Object.keys(merged).length > 0 ? merged : undefined;
+};
+
+/** Normalize `$models` entries so adapters always see merged `fields`. */
+const resolveModels = <M extends StorageModels>(models: M): M => {
+	const out: Record<string, unknown> = {};
+	for (const [key, input] of Object.entries(models)) {
+		if (isVar(input)) {
+			const fields = resolveModelFields(input);
+			out[key] = fields === undefined ? input : { schema: input, fields };
+			continue;
+		}
+		const config = input as ModelConfig;
+		const fields = resolveModelFields(config);
+		out[key] = fields === undefined ? { ...config } : { ...config, fields };
+	}
+	return out as M;
 };
 
 /** What an op subscription hands back: `v.on` entries to mount. */
@@ -557,7 +610,7 @@ const buildStorage = <M extends StorageModels>(
 				? state.adapter.transaction((tx) => inside(tx))
 				: inside(state.adapter);
 		},
-		$models: models,
+		$models: resolveModels(models),
 	} as StorageApi<M>) as Storage<M>;
 	return self;
 };

--- a/packages/experimental/src/storage.ts
+++ b/packages/experimental/src/storage.ts
@@ -333,13 +333,15 @@ export const resolveModelFields = (
 	return Object.keys(merged).length > 0 ? merged : undefined;
 };
 
-/** Normalize `$models` entries so adapters always see merged `fields`. */
+/** Normalize `$models` entries so adapters always see merged `fields`.
+ * Bare vars stay bare vars (identity preserved); use
+ * {@link resolveModelFields} to read schema attrs off them. ModelConfig
+ * entries get `fields` filled from schema attrs + overrides. */
 const resolveModels = <M extends StorageModels>(models: M): M => {
 	const out: Record<string, unknown> = {};
 	for (const [key, input] of Object.entries(models)) {
 		if (isVar(input)) {
-			const fields = resolveModelFields(input);
-			out[key] = fields === undefined ? input : { schema: input, fields };
+			out[key] = input;
 			continue;
 		}
 		const config = input as ModelConfig;

--- a/packages/experimental/src/var.ts
+++ b/packages/experimental/src/var.ts
@@ -79,6 +79,10 @@ export const makeVar = (name: string, options: any = {}): any => {
 			makeVar(name, {
 				...options,
 				default: def.default,
+				// Carry whole-var attrs through customize (including any
+				// attached after mint via withAttrs-rebinding, which goes
+				// through its own path; this covers options.attrs).
+				...(def.$attrs !== undefined ? { attrs: def.$attrs } : {}),
 				schema: opts.schema({
 					...vTypes,
 					fn: fnImpl,

--- a/packages/experimental/src/var.ts
+++ b/packages/experimental/src/var.ts
@@ -4,6 +4,7 @@ import { ValidationError } from "./error";
 import { type Fn, fnImpl } from "./fn";
 import { matchesTarget, type OnEntry } from "./module";
 import {
+	type AttrBag,
 	asType,
 	type DefineOutput,
 	type InferArgs,
@@ -28,6 +29,8 @@ export interface VarDefination<
 	/** Phantom: the var this one derives from - `requires` on the source
 	 * makes this one non-null too. */
 	$source?: Source;
+	/** Whole-var plugin attributes (field attrs live on the schema). */
+	$attrs?: AttrBag;
 	customize: <S>(options: {
 		schema: (v: VarCustomizer<T>) => S;
 	}) => VarDefination<N, InferInput<S>, S>;
@@ -69,6 +72,7 @@ export const makeVar = (name: string, options: any = {}): any => {
 		name,
 		default: options.default,
 		schema,
+		...(options.attrs !== undefined ? { $attrs: options.attrs } : {}),
 		$accessor: options.accessor === true,
 		$derive: options.derive,
 		customize: (opts: any) =>

--- a/packages/experimental/tsdown.config.ts
+++ b/packages/experimental/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
 		schema: "src/schema.ts",
 		"plugins/http": "src/plugins/http/index.ts",
 		"plugins/read-only": "src/plugins/read-only.ts",
+		"plugins/db": "src/plugins/db.ts",
 		capability: "src/capability.ts",
 	},
 	dts: { build: true, incremental: true },


### PR DESCRIPTION
## Summary

Adds a hybrid field-attribute system so plugins can stamp metadata on schema fields without core interpreting the keys.

- Core `$attrs` bag on type defs (`withAttrs` / `attrsOf`); validate and `InferArgs` stay unchanged.
- HTTP: `serverOnly`, `clientSchema`, `wireInput` / `fromJsonBody`; capability `serve` rejects smuggled server-only fields on the wire while in-process calls still accept them.
- DB plugin (`better-call/plugins/db`): `unique` / `indexed` / `references`; `$models` merges `$attrs.db` with `ModelConfig.fields` (fields wins as override).