### PR TITLE
fix(experimental): widen declaring fn input types for mounted v.extend

### DIFF
--- a/packages/experimental/src/fn.ts
+++ b/packages/experimental/src/fn.ts
@@ -8,6 +8,8 @@ import {
 import {
 	type ApplyOns,
 	collectUsable,
+	type InputVarExtra,
+	type InputVarExtraOut,
 	isFn,
 	isNamespace,
 	isOn,
@@ -214,6 +216,20 @@ export type ArgsOf<I> = I extends readonly unknown[]
 		? void
 		: InferArgs<I>;
 
+/**
+ * Call args of a declaring fn: the declared input, plus whatever mounted
+ * `v.extend` / same-name shadows add for vars that input references.
+ * Mirrors {@link ApplyOn} so `input: user` + `use: [userWithEmail]` types
+ * the door the same way a used call site would.
+ */
+export type WidenedArgs<I, ExtPL> =
+	unknown extends InputVarExtra<ExtPL, I>
+		? ArgsOf<I>
+		: Prettify<
+				([ArgsOf<I>] extends [void] ? unknown : ArgsOf<I>) &
+					InputVarExtra<ExtPL, I>
+			>;
+
 export type OptionType<
 	I,
 	O,
@@ -336,8 +352,12 @@ export type Context<
 	FnApi = Fn,
 	RO extends boolean = false,
 	Errs = NoErrors,
+	/** Modules that widen var-bound input (this fn's `use` + builder chain). */
+	ExtPL = unknown,
 > = {
-	input: InferInput<I>;
+	input: unknown extends InputVarExtraOut<ExtPL, I>
+		? InferInput<I>
+		: Prettify<InferInput<I> & InputVarExtraOut<ExtPL, I>>;
 	/**
 	 * Mint a DECLARED error - tag-checked, payload validated at creation:
 	 * `throw c.error("invalid_credentials", { attempts: 3 })`. Only tags
@@ -462,11 +482,12 @@ export interface Fn<
 					Prefix
 				>,
 				RO,
-				Er
+				Er,
+				readonly [...BasePL, ...PL]
 			>,
 		) => R,
 	): PublicFn<
-		ArgsOf<I>,
+		WidenedArgs<I, readonly [...BasePL, ...PL]>,
 		R,
 		Prefix extends "" ? string : Prefix,
 		I,
@@ -502,11 +523,12 @@ export interface Fn<
 					`${Prefix}${K}`
 				>,
 				RO,
-				Er
+				Er,
+				readonly [...BasePL, ...PL]
 			>,
 		) => R,
 	): PublicFn<
-		ArgsOf<I>,
+		WidenedArgs<I, readonly [...BasePL, ...PL]>,
 		R,
 		`${Prefix}${K}`,
 		I,

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -100,6 +100,7 @@ export type {
 	OptionType,
 	ParentContext,
 	UseApi,
+	WidenedArgs,
 	WithContext,
 	WithSeed,
 } from "./fn";
@@ -109,6 +110,8 @@ export {
 	collectFns,
 	collectUsable,
 	type ExtendedArgs,
+	type InputVarExtra,
+	type InputVarExtraOut,
 	type Interceptor,
 	isFn,
 	isNamespace,

--- a/packages/experimental/src/module.ts
+++ b/packages/experimental/src/module.ts
@@ -538,6 +538,28 @@ export type InputVarExtra<PL, I> = I extends {
 					: unknown;
 			};
 
+/**
+ * Same merge as {@link InputVarExtra}, on the PARSED side - what the
+ * handler sees on `c.input` after mounted extensions have been applied.
+ */
+export type InputVarExtraOut<PL, I> = I extends {
+	$var: true;
+	name: infer N extends string;
+}
+	? VarExtensionsFor<PL, N>
+	: [VarFieldKeys<I>] extends [never]
+		? unknown
+		: {
+				[K in keyof I as I[K] extends { $var: true }
+					? K
+					: never]: I[K] extends {
+					$var: true;
+					name: infer N extends string;
+				}
+					? VarExtensionsFor<PL, N>
+					: unknown;
+			};
+
 /* ------------------------------- extension -------------------------------- */
 
 type ExtEntryArgs<M, K extends string> = M extends unknown

--- a/packages/experimental/src/var.test.ts
+++ b/packages/experimental/src/var.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { v } from "./index";
 
 describe("vars", () => {
@@ -74,20 +74,36 @@ describe("var extensions", () => {
 	const withTag = v.extend(account, { tag: v.string() });
 
 	it("mounted extensions widen a var-bound input at runtime", () => {
-		const f = v.fn(
-			{ input: account, use: [{ account, withTag }] },
-			(c) => c.vt_account,
-		);
-		expect(f({ id: "a", tag: "vip" } as never)).toEqual({
+		const f = v.fn({ input: account, use: [{ account, withTag }] }, (c) => {
+			expectTypeOf(c.input).toEqualTypeOf<{ id: string; tag: string }>();
+			return c.vt_account;
+		});
+		expectTypeOf(f).parameter(0).toEqualTypeOf<{ id: string; tag: string }>();
+		expect(f({ id: "a", tag: "vip" })).toEqual({
 			id: "a",
 			tag: "vip",
 		});
+		// @ts-expect-error tag required once withTag is mounted
 		expect(() => f({ id: "a" })).toThrow(/vt_account/);
 	});
 
 	it("unmounted, nothing changes", () => {
-		const f = v.fn({ input: account, use: [{ account }] }, (c) => c.vt_account);
+		const f = v.fn({ input: account, use: [{ account }] }, (c) => {
+			expectTypeOf(c.input).toEqualTypeOf<{ id: string }>();
+			return c.vt_account;
+		});
+		expectTypeOf(f).parameter(0).toEqualTypeOf<{ id: string }>();
 		expect(f({ id: "a" })).toEqual({ id: "a" });
+	});
+
+	it("builder-mounted extensions widen a later input: var the same way", () => {
+		const s = v.fn({ use: [{ account, withTag }] });
+		const f = s.fn({ input: account }, (c) => {
+			expectTypeOf(c.input).toEqualTypeOf<{ id: string; tag: string }>();
+			return c.input;
+		});
+		expectTypeOf(f).parameter(0).toEqualTypeOf<{ id: string; tag: string }>();
+		expect(f({ id: "b", tag: "gold" })).toEqual({ id: "b", tag: "gold" });
 	});
 });
 


### PR DESCRIPTION
## Summary

`input: user` with a mounted `v.extend` already widened the var at runtime and on used call sites via `ApplyOn`, but the declaring fn still typed its door and `c.input` as the base schema.

- Add `InputVarExtraOut` (parsed-side twin of `InputVarExtra`) and `WidenedArgs` so declaring fns apply the same merge.
- Thread the builder's `BasePL` + own `use` into `Context` as `ExtPL`, so extensions mounted on a parent builder widen later `input: var` the same way.
- Keep `c.input` as plain `InferInput<I>` when nothing extends, so fn-schema inputs keep their call signatures (`Prettify` would strip them).