### PR TITLE
fix(experimental): allow zero-arg calls when input is omittable

### DIFF
--- a/packages/experimental/src/fn.test.ts
+++ b/packages/experimental/src/fn.test.ts
@@ -67,6 +67,73 @@ describe("v.fn call forms", () => {
 	});
 });
 
+describe("omittable input", () => {
+	it("optional object schema allows a zero-arg call", () => {
+		const id = v.fn(
+			"fnt.id",
+			{
+				input: v.object(
+					{ size: v.number({ optional: true, default: 32 }) },
+					{ optional: true },
+				),
+				output: v.string(),
+			},
+			(c) => (c.input === undefined ? "none" : `s${c.input.size}`),
+		);
+		expect(id()).toBe("none");
+		expect(id({ size: 8 })).toBe("s8");
+		expectTypeOf(id).toBeCallableWith();
+		expectTypeOf(id).toBeCallableWith({ size: 8 });
+	});
+
+	it("all-optional fields allow omit without { optional: true } on the object", () => {
+		const f = v.fn(
+			"fnt.opts",
+			{ input: { size: v.number({ optional: true, default: 32 }) } },
+			(c) => c.input.size,
+		);
+		expect(f()).toBe(32);
+		expect(f({})).toBe(32);
+		expectTypeOf(f).toBeCallableWith();
+		type Optional = undefined extends Parameters<typeof f>[0] ? true : false;
+		expectTypeOf<Optional>().toEqualTypeOf<true>();
+	});
+
+	it("required fields stay required on the call", () => {
+		const f = v.fn("fnt.need", { input: { n: v.number() } }, (c) => c.input.n);
+		expect(f({ n: 1 })).toBe(1);
+		expectTypeOf(f).toBeCallableWith({ n: 1 });
+		type Required = undefined extends Parameters<typeof f>[0] ? true : false;
+		expectTypeOf<Required>().toEqualTypeOf<false>();
+	});
+
+	it("bound used fns allow zero-arg when input is omittable", () => {
+		const generateId = v.fn(
+			"fnt.generateId",
+			{
+				input: v.object({
+					size: v.number({ optional: true, default: 16 }),
+				}),
+			},
+			(c) => c.input.size,
+		);
+		const outer = v.fn({ use: [{ generateId }] }, (c) => c.generateId());
+		expect(outer()).toBe(16);
+		expectTypeOf(outer).toBeCallableWith();
+	});
+
+	it("open v.object() still requires an object arg", () => {
+		const f = v.fn("fnt.open", { input: v.object() }, (c) => c.input);
+		expect(f({ a: 1 })).toEqual({ a: 1 });
+		expectTypeOf(f).toBeCallableWith({ a: 1 });
+		type Required = undefined extends Parameters<typeof f>[0] ? true : false;
+		expectTypeOf<Required>().toEqualTypeOf<false>();
+		expect(() => (f as (input?: unknown) => unknown)()).toThrow(
+			/expected object/,
+		);
+	});
+});
+
 describe("builder", () => {
 	it("keys concatenate down the chain", () => {
 		const leaf = v

--- a/packages/experimental/src/fn.ts
+++ b/packages/experimental/src/fn.ts
@@ -33,6 +33,7 @@ import {
 	isVar,
 	type OutputSchemaOf,
 	outputContract,
+	type TypeDefination,
 	validate,
 	vTypes,
 } from "./schema";
@@ -50,15 +51,42 @@ import {
 
 export type ParentContext = Record<string, any>;
 
+/**
+ * `{}` assignable to `A`, and `A` is not an open index signature
+ * (`Record<string, …>` / `v.object()` with no shape). Those accept any
+ * object, so omitting the arg is not the same as sending one.
+ */
+type EmptyExtendsArgs<A> =
+	Record<never, never> extends A
+		? string extends keyof A
+			? false
+			: true
+		: false;
+
+/**
+ * Callers may omit a non-tuple input when the schema is optional or
+ * defaulted, or every field is already optional to send.
+ */
+type InputOmittable<A, I> = I extends { $var: true; schema?: infer S }
+	? InputOmittable<A, NonNullable<S>>
+	: I extends TypeDefination<any, any, infer D>
+		? [D] extends [never]
+			? EmptyExtendsArgs<A>
+			: true
+		: EmptyExtendsArgs<A>;
+
 /** The call shape: a TUPLE input spreads - one parameter per position,
- * the parent context last. Everything else takes (input?, parent?). */
+ * the parent context last. No input, or an omittable one, takes
+ * `(input?, parent?)`; required inputs stay required. */
 type CallArgs<A, I> = I extends readonly unknown[]
 	? A extends readonly unknown[]
 		? [...A] | [...A, ParentContext]
 		: never
 	: [A] extends [void]
 		? [input?: undefined, parent?: ParentContext]
-		: [input: A, parent?: ParentContext];
+		: InputOmittable<A, I> extends true
+			? [input?: A, parent?: ParentContext]
+			: [input: A, parent?: ParentContext];
 
 /** The union of a fn's DECLARED errors, as thrown values. */
 export type FnErrorsOf<Er> = {
@@ -288,7 +316,7 @@ export type OptionType<
 };
 
 /** A used fn, with the parent context already applied. A tuple-input fn
- * keeps its positional signature. */
+ * keeps its positional signature. Omittable inputs match {@link CallArgs}. */
 type BoundFn<F> =
 	F extends FnDefination<infer A, infer R, string, infer I, any, any>
 		? I extends readonly unknown[]
@@ -297,7 +325,9 @@ type BoundFn<F> =
 				: never
 			: [A] extends [void]
 				? () => R
-				: (input: A) => R
+				: InputOmittable<A, I> extends true
+					? (input?: A) => R
+					: (input: A) => R
 		: never;
 
 /** Keys of a usable map whose member is a VAR alias. */

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -475,10 +475,13 @@ export const validate = (
 	path: string,
 ): any => {
 	// `undefined` falls back to the declared default before anything else,
-	// then to `optional`, which passes it through untouched.
+	// then to `optional`, which passes it through untouched. A shaped
+	// object with no default treats omit as `{}` so all-optional fields
+	// can be left off the call without a dummy payload.
 	if (value === undefined) {
 		if (def.default !== undefined) value = def.default;
 		else if (def.optional) return undefined;
+		else if (def.name === "object" && def.shape !== undefined) value = {};
 	}
 	// A var used as an input field validates against its own schema. An
 	// absent value is left alone so the var keeps its default.


### PR DESCRIPTION
## Summary

`CallArgs` / `BoundFn` only allowed a zero-arg call when there was no input (`ArgsOf` is `void`). A schema marked `{ optional: true }`, or one where every field is optional/defaulted, still required the first argument, so `fn()` and `c.generateId()` failed with "Expected 1–2 arguments, but got 0" even though omit is legal.

- Treat input as optional when the schema is optional/defaulted, or when `{}` is assignable to the args shape (excluding open `v.object()`).
- Align `BoundFn` the same way so used calls like `c.generateId()` work without a dummy `{}`.
- At validate time, treat omit of a shaped object as `{}` so field defaults still apply.