### PR TITLE
fix(experimental): keep optional schema absence on c.input

### DIFF
--- a/packages/experimental/src/fn.test.ts
+++ b/packages/experimental/src/fn.test.ts
@@ -86,6 +86,34 @@ describe("omittable input", () => {
 		expectTypeOf(id).toBeCallableWith({ size: 8 });
 	});
 
+	it("optional object omit is undefined - field defaults do not run", () => {
+		// `{ optional: true }` on the object means "may be absent". An absent
+		// payload stays undefined; size's default only applies when an object
+		// was actually sent. InferInput must carry `| undefined` so
+		// `c.input.size` is not typed as a bare number.
+		const generateId = v.fn(
+			"fnt.generateId",
+			{
+				input: v.object(
+					{ size: v.number({ optional: true, default: 32 }) },
+					{ optional: true },
+				),
+				output: v.string(),
+			},
+			(c) => {
+				expectTypeOf(c.input).toEqualTypeOf<{ size: number } | undefined>();
+				if (c.input === undefined) return "missing";
+				expectTypeOf(c.input.size).toEqualTypeOf<number>();
+				return `s${c.input.size}`;
+			},
+		);
+		expect(generateId()).toBe("missing");
+		expect(generateId(undefined)).toBe("missing");
+		// An empty object is present - field defaults apply.
+		expect(generateId({})).toBe("s32");
+		expect(generateId({ size: 8 })).toBe("s8");
+	});
+
 	it("all-optional fields allow omit without { optional: true } on the object", () => {
 		const f = v.fn(
 			"fnt.opts",

--- a/packages/experimental/src/module.ts
+++ b/packages/experimental/src/module.ts
@@ -515,6 +515,10 @@ type VarFieldKeys<I> = {
 	[K in keyof I]: I[K] extends { $var: true } ? K : never;
 }[keyof I];
 
+/** Optional props put `undefined` in the key union; strip it so "no var
+ * fields" still reads as `never` and InputVarExtra stays `unknown`. */
+type VarFields<I> = Exclude<VarFieldKeys<I>, undefined>;
+
 /**
  * Extra args a fn must accept because its INPUT references vars that `PL`
  * extends. Whole-var input (`input: user`) merges at the top level; a var
@@ -525,7 +529,7 @@ export type InputVarExtra<PL, I> = I extends {
 	name: infer N extends string;
 }
 	? VarExtensionArgsFor<PL, N>
-	: [VarFieldKeys<I>] extends [never]
+	: [VarFields<I>] extends [never]
 		? unknown
 		: {
 				[K in keyof I as I[K] extends { $var: true }
@@ -547,7 +551,7 @@ export type InputVarExtraOut<PL, I> = I extends {
 	name: infer N extends string;
 }
 	? VarExtensionsFor<PL, N>
-	: [VarFieldKeys<I>] extends [never]
+	: [VarFields<I>] extends [never]
 		? unknown
 		: {
 				[K in keyof I as I[K] extends { $var: true }

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -67,6 +67,22 @@ type DefOf<D, Opt> = [Opt] extends [true]
 		: D
 	: D;
 
+/**
+ * Recover a type's output `O`. Plain `infer O` from
+ * `TypeDefination<any, infer O, …>` drops `| undefined` because `output?`
+ * is optional and TypeScript attributes the undefined to the property.
+ * When DefOf is `undefined` (optional, no default), put `| undefined`
+ * back so handlers see the same absence validate produces at runtime.
+ */
+type OutputOf<F> =
+	F extends TypeDefination<any, infer O, infer D>
+		? [D] extends [never]
+			? O
+			: undefined extends D
+				? O | undefined
+				: O
+		: never;
+
 type StringOptions<E extends string, O> = TypeOptions<E, O> &
 	Pick<
 		Rules,
@@ -93,7 +109,7 @@ export type InferType<T> =
 	T extends TypeDefination<infer T2, any, any> ? T2 : never;
 
 export type InferOutput<T> =
-	T extends TypeDefination<any, infer O, any> ? O : never;
+	T extends TypeDefination<any, any, any> ? OutputOf<T> : never;
 
 export type DefineInput<I> = Prettify<{
 	[K in keyof I]: FieldIn<I[K]>;
@@ -222,8 +238,8 @@ type FieldOut<F> = F extends { $var: true; schema?: infer S }
 	? InferInput<NonNullable<S>>
 	: F extends { $fnSchema: { input?: infer FI; output?: infer FO } }
 		? SchemaFnOut<FI, FO> & FnVarBrand<FI>
-		: F extends TypeDefination<any, infer O, any>
-			? O
+		: F extends TypeDefination<any, any, any>
+			? OutputOf<F>
 			: F extends Record<string, unknown>
 				? Prettify<{ [K in keyof F]: FieldOut<F[K]> }>
 				: never;
@@ -279,8 +295,8 @@ export type InferInput<I> = I extends { $var: true; schema?: infer S }
 		? SchemaFnOut<FI, FO> & FnVarBrand<FI>
 		: I extends readonly unknown[]
 			? { -readonly [K in keyof I]: InferInput<I[K]> }
-			: I extends TypeDefination<any, infer O, any>
-				? O
+			: I extends TypeDefination<any, any, any>
+				? OutputOf<I>
 				: Prettify<{ [K in keyof I]: FieldOut<I[K]> }>;
 
 /** Pre-transform shape - what a caller sends. Same branch order. */


### PR DESCRIPTION
## Summary

An input schema like `v.object({ size: v.number({ default: 32 }) }, { optional: true })` validates to `undefined` when omitted, but `c.input` was still typed as `{ size: number }`. Field defaults on size made the property look always present even though the outer object never arrived.

Two type bugs stacked:

- `infer O` from `TypeDefination` drops `| undefined` because `output?` is optional, so TypeScript attributes the undefined to the property instead of `O`.
- `InputVarExtraOut` treated schemas with no var fields as having some (optional keys put `undefined` in the key union), so Context took the merge branch with `{}` and `InferInput & {}` stripped `| undefined` again.

Restore absence through `OutputOf`, and `Exclude` `undefined` from the var-field never check so plain schemas stay on the `InferInput` path.