### PR TITLE
fix(experimental): widen storage collection types for mounted v.extend

### DIFF
--- a/packages/experimental/README.md
+++ b/packages/experimental/README.md
@@ -81,6 +81,16 @@ app.fn("auth.x", async (c) => {
 });
 ```
 
+The same scope rewrite applies to **`v.storage` collections**: `c.db.user.findOne({ email })` / `findMany` / `update` (and their return types) re-resolve against mounted extensions — no mirror helpers on the db schema.
+
+```ts
+const store = v.storage(memoryAdapter(), { user }); // user is still { id }
+const app = v.fn({ use: [{ user, userWithEmail, db: store }] });
+app.fn("auth.x", async (c) => {
+  await c.db.user.findOne({ email: "a@b.c" }); // Where includes email HERE
+});
+```
+
 ### errors
 
 Errors are the third contract door: input validates on entry, output on exit, errors at throw. A fn declares its failures as `tag -> payload schema`; `c.error` only accepts declared tags and validates the payload at mint:

--- a/packages/experimental/src/fn.ts
+++ b/packages/experimental/src/fn.ts
@@ -350,7 +350,9 @@ export type UseApi<U> = Prettify<
 			any
 		>
 			? BoundFn<U[K]>
-			: UseApi<U[K]>;
+			: U[K] extends { $models: object }
+				? U[K]
+				: UseApi<U[K]>;
 	} & { [K in UseVarKeys<U>]: UseVarValue<U[K]> }
 >;
 
@@ -370,7 +372,9 @@ type ReadUseApi<U> = Prettify<
 			? P extends readonly []
 				? BoundFn<U[K]>
 				: `writes "${P[number] & string}" - not callable from a readonly fn`
-			: ReadUseApi<U[K]>;
+			: U[K] extends { $models: object }
+				? U[K]
+				: ReadUseApi<U[K]>;
 	} & { readonly [K in UseVarKeys<U>]: UseVarValue<U[K]> }
 >;
 
@@ -869,6 +873,16 @@ const defineFn = (
 						enumerable: true,
 						configurable: true,
 					});
+					continue;
+				}
+				// Storage mounts whole - do not walk `$models` as a namespace.
+				if (
+					typeof used === "object" &&
+					used !== null &&
+					"$models" in used &&
+					typeof (used as { $adapter?: unknown }).$adapter === "function"
+				) {
+					target[name] = override !== undefined ? override : used;
 					continue;
 				}
 				if (!isFn(used)) {

--- a/packages/experimental/src/fn.ts
+++ b/packages/experimental/src/fn.ts
@@ -132,11 +132,14 @@ type WithFns<U> = {
  * is what `v.fn` returns, and stays declaration-emit safe. */
 export type WithContext<RV, U> = { [K in keyof RV]?: RV[K] } & WithFns<U>;
 
-/** Storage (or the FnEntries slice of one): anything carrying `$models`.
- * Nested under a module as `{ db }`, it must not flow into `.with` seeds -
- * model schemas alone blow past declaration serialize limits. ModuleFns
- * drops `$adapter`/`$on`/collections, so duck-typing `$models` alone. */
-type StorageLike = { $models: object };
+/** Storage (or the FnEntries slice of one): `$models` plus callable
+ * `$adapter`. Nested under a module as `{ db }`, it must not flow into
+ * `.with` seeds - model schemas alone blow past declaration serialize
+ * limits. ModuleFns keeps collections; WithSeed still drops storage. */
+type StorageLike = {
+	$models: object;
+	$adapter: (...args: never[]) => unknown;
+};
 
 /** Flatten `use` members to `.with` overrides: bound call signatures, var
  * alias values, nested groups. Storage is dropped (mount-only). */
@@ -350,7 +353,7 @@ export type UseApi<U> = Prettify<
 			any
 		>
 			? BoundFn<U[K]>
-			: U[K] extends { $models: object }
+			: U[K] extends StorageLike
 				? U[K]
 				: UseApi<U[K]>;
 	} & { [K in UseVarKeys<U>]: UseVarValue<U[K]> }
@@ -372,7 +375,7 @@ type ReadUseApi<U> = Prettify<
 			? P extends readonly []
 				? BoundFn<U[K]>
 				: `writes "${P[number] & string}" - not callable from a readonly fn`
-			: U[K] extends { $models: object }
+			: U[K] extends StorageLike
 				? U[K]
 				: ReadUseApi<U[K]>;
 	} & { readonly [K in UseVarKeys<U>]: UseVarValue<U[K]> }

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -140,6 +140,7 @@ export {
 } from "./schema";
 export type {
 	ResolvedVars,
+	RowInScope,
 	ScopeOf,
 	VarName,
 	VarScope,
@@ -151,6 +152,7 @@ export {
 	type FieldMeta,
 	type FindManyOptions,
 	fieldsFromSchema,
+	isStorage,
 	type ModelConfig,
 	matchesWhere,
 	memoryAdapter,

--- a/packages/experimental/src/module.ts
+++ b/packages/experimental/src/module.ts
@@ -9,9 +9,14 @@ import type {
 } from "./types";
 import type { VarDefination } from "./var";
 
-/** Storage (or a slice): anything carrying `$models`. Kept opaque in
- * {@link ModuleFns} so collections stay on `c.db`, not walked as groups. */
-type StorageLike = { $models: object };
+/** Storage (or a slice): `$models` plus callable `$adapter`. Kept opaque
+ * in {@link ModuleFns} so collections stay on `c.db`, not walked as groups.
+ * Matches runtime detection (`$adapter` required) so a plain namespace that
+ * happens to have a `$models` key is still walked for nested fns/vars. */
+type StorageLike = {
+	$models: object;
+	$adapter: (...args: never[]) => unknown;
+};
 
 export type Interceptor = (c: any, next: () => Promise<any>) => any;
 

--- a/packages/experimental/src/module.ts
+++ b/packages/experimental/src/module.ts
@@ -1,5 +1,6 @@
 import type { FnDefination } from "./fn";
 import { type InferArgs, type InferInput, isVar, type vTypes } from "./schema";
+import type { WidenSchemaFns } from "./scope";
 import type {
 	LiteralString,
 	Members,
@@ -7,6 +8,10 @@ import type {
 	UnionToIntersection,
 } from "./types";
 import type { VarDefination } from "./var";
+
+/** Storage (or a slice): anything carrying `$models`. Kept opaque in
+ * {@link ModuleFns} so collections stay on `c.db`, not walked as groups. */
+type StorageLike = { $models: object };
 
 export type Interceptor = (c: any, next: () => Promise<any>) => any;
 
@@ -98,11 +103,13 @@ export type Module = Record<string, unknown> & {
 };
 
 /** A module member that can NEST other members: a plain record that is
- * not itself branded. Fn defs are callable, so they never match. */
+ * not itself branded. Fn defs are callable, so they never match. Storage
+ * stays opaque (collections are not a nested module group). */
 type GroupMember<V> = V extends
 	| { $var: true }
 	| { $on: true }
 	| { $varExtend: true }
+	| StorageLike
 	| ((...args: any[]) => any)
 	| readonly unknown[]
 	? never
@@ -158,13 +165,17 @@ type FnEntries<M, D extends number = 3> = {
 		? K
 		: M[K] extends VarDefination<any, any, any, any>
 			? K
-			: [GroupFns<M[K], GroupDepth[D]>] extends [never]
-				? never
-				: K]: M[K] extends FnDefination<any, any, any, any, any, any>
+			: M[K] extends StorageLike
+				? K
+				: [GroupFns<M[K], GroupDepth[D]>] extends [never]
+					? never
+					: K]: M[K] extends FnDefination<any, any, any, any, any, any>
 		? M[K]
 		: M[K] extends VarDefination<any, any, any, any>
 			? M[K]
-			: GroupFns<M[K], GroupDepth[D]>;
+			: M[K] extends StorageLike
+				? M[K]
+				: GroupFns<M[K], GroupDepth[D]>;
 };
 
 /** Fns and vars a module exports, keyed by EXPORT name. A plain-record
@@ -217,8 +228,8 @@ export const collectFns = (
 /**
  * A plain-record member that GROUPS other members - not itself branded
  * (fn, var, on entry, var extension) but holding at least one such member,
- * transitively. Storages and other `$`-surfaced objects fail the member
- * test and stay opaque values.
+ * transitively. Storages stay opaque values (their `$models` are not a
+ * nested module group).
  */
 export const isNamespace = (
 	value: unknown,
@@ -229,6 +240,13 @@ export const isNamespace = (
 	const proto = Object.getPrototypeOf(value);
 	if (proto !== Object.prototype && proto !== null) return false;
 	if (isVar(value) || isOn(value) || isVarExtension(value)) return false;
+	// Storage: `$models` + `$adapter` - not a namespace of module members.
+	if (
+		"$models" in value &&
+		typeof (value as { $adapter?: unknown }).$adapter === "function"
+	) {
+		return false;
+	}
 	return Object.values(value).some(
 		(m) =>
 			isFn(m) || isVar(m) || isOn(m) || isVarExtension(m) || isNamespace(m),
@@ -240,15 +258,21 @@ export const isNamespace = (
  * namespaces: `use: [{ cookie: { setCookie } }]` lands the fn on
  * `c.cookie.setCookie`. A var member becomes an ALIAS under its export
  * name (`{ cookie: { options: cookieOptions } }` -> `c.cookie.options`
- * reads/writes the var). Groups holding nothing (however deep) drop out.
+ * reads/writes the var). Storage mounts whole (`c.db.user.findOne`).
+ * Groups holding nothing (however deep) drop out.
  */
 export const collectUsable = (
 	modules: readonly Module[],
 ): Record<string, unknown> => {
+	const isStorageValue = (value: unknown) =>
+		typeof value === "object" &&
+		value !== null &&
+		"$models" in value &&
+		typeof (value as { $adapter?: unknown }).$adapter === "function";
 	const walk = (mod: Record<string, unknown>): Record<string, unknown> => {
 		const out: Record<string, unknown> = {};
 		for (const [name, value] of Object.entries(mod)) {
-			if (isFn(value) || isVar(value)) {
+			if (isFn(value) || isVar(value) || isStorageValue(value)) {
 				out[name] = value;
 			} else if (isNamespace(value)) {
 				const nested = walk(value);
@@ -586,19 +610,23 @@ export type ExtendedArgs<PL, K extends string> = UnionToIntersection<
 /**
  * Rewrite a fn's type with the input extensions the module set `PL`
  * mounts on it. This is how a plugin's extra field becomes REQUIRED at
- * the call site, even though the fn itself never declared it.
+ * the call site, even though the fn itself never declared it. Storage
+ * members get the same scope rewrite as a db var's value ({@link
+ * WidenSchemaFns}): collections re-resolve row/`Where` types against
+ * mounted `v.extend` / customize.
  */
-export type ApplyOn<F, PL> =
-	F extends FnDefination<
-		infer A,
-		infer R,
-		infer K,
-		infer I,
-		infer P,
-		infer Er,
-		infer W,
-		infer O
-	>
+export type ApplyOn<F, PL> = F extends StorageLike
+	? WidenSchemaFns<F, PL>
+	: F extends FnDefination<
+				infer A,
+				infer R,
+				infer K,
+				infer I,
+				infer P,
+				infer Er,
+				infer W,
+				infer O
+			>
 		? unknown extends ExtendedArgs<PL, K & string> & InputVarExtra<PL, I>
 			? F
 			: FnDefination<

--- a/packages/experimental/src/scope.ts
+++ b/packages/experimental/src/scope.ts
@@ -1,4 +1,5 @@
 import type { ModuleVars, VarArgsInScope, VarExtensionsFor } from "./module";
+import type { Collection } from "./storage";
 import type { Prettify } from "./types";
 import type { VarDefination } from "./var";
 
@@ -12,6 +13,28 @@ type MergeExtension<T, E> = T extends object ? Prettify<T & E> : T;
 
 type Merged<PL, Base> = ModuleVars<PL> & Base;
 
+export type ResolvedVars<PL> = {
+	[K in keyof ModuleVars<PL>]: MergeExtension<
+		ModuleVars<PL>[K],
+		VarExtensionsFor<PL, K & string>
+	>;
+};
+
+/**
+ * Row shape a collection uses inside scope `PL`: the model var as the
+ * scope sees it (extensions + same-name customize), falling back to the
+ * declared row plus any mounted `v.extend` fields.
+ */
+export type RowInScope<
+	R,
+	PL,
+	N extends string,
+> = N extends keyof ResolvedVars<PL>
+	? NonNullable<ResolvedVars<PL>[N]>
+	: unknown extends VarExtensionsFor<PL, N>
+		? R
+		: Prettify<R & VarExtensionsFor<PL, N>>;
+
 type WidenSchemaFn<T, PL> = T extends {
 	$fnVar?: [infer N extends string];
 }
@@ -24,27 +47,35 @@ type WidenSchemaFn<T, PL> = T extends {
 		: T
 	: T;
 
-export type WidenSchemaFns<T, PL> = T extends (...args: any[]) => any
-	? WidenSchemaFn<T, PL>
-	: T extends readonly unknown[]
-		? { [K in keyof T]: WidenSchemaFns<T[K], PL> }
-		: T extends Date | RegExp | Promise<unknown> | Map<any, any> | Set<any>
+/**
+ * Rewrite a `$modelVar`-branded collection so `Where` / returns use the
+ * composed model shape - same PL math as {@link WidenSchemaFn} / {@link
+ * ResolvedVars}.
+ */
+type WidenCollection<T, PL> =
+	T extends Collection<infer R, infer N>
+		? [R] extends [RowInScope<R, PL, N & string>]
 			? T
-			: T extends object
+			: Collection<RowInScope<R, PL, N & string>, N & string>
+		: T;
+
+export type WidenSchemaFns<T, PL> =
+	T extends Collection<any, string>
+		? WidenCollection<T, PL>
+		: T extends (...args: any[]) => any
+			? WidenSchemaFn<T, PL>
+			: T extends readonly unknown[]
 				? { [K in keyof T]: WidenSchemaFns<T[K], PL> }
-				: T;
+				: T extends Date | RegExp | Promise<unknown> | Map<any, any> | Set<any>
+					? T
+					: T extends object
+						? { [K in keyof T]: WidenSchemaFns<T[K], PL> }
+						: T;
 
 export type ScopeOf<PL, Base = unknown, ExtPL = PL> = {
 	[K in keyof Merged<PL, Base>]: WidenSchemaFns<
 		MergeExtension<Merged<PL, Base>[K], VarExtensionsFor<ExtPL, K & string>>,
 		ExtPL
-	>;
-};
-
-export type ResolvedVars<PL> = {
-	[K in keyof ModuleVars<PL>]: MergeExtension<
-		ModuleVars<PL>[K],
-		VarExtensionsFor<PL, K & string>
 	>;
 };
 

--- a/packages/experimental/src/storage.test.ts
+++ b/packages/experimental/src/storage.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import {
 	memoryAdapter,
 	resolveModelFields,
@@ -6,6 +6,7 @@ import {
 	v,
 } from "./index";
 import { db, indexed, references, unique } from "./plugins/db";
+import type { WhereOps } from "./storage";
 
 describe("v.storage", () => {
 	it("many instances of a var: CRUD in the var's shape", async () => {
@@ -477,5 +478,96 @@ describe("v.storage", () => {
 		const db = v.storage(spy, { alias: named });
 		await db.alias.create({ id: "1" });
 		expect(models).toEqual(["stg_named"]);
+	});
+});
+
+describe("storage collection var widening", () => {
+	const user = v.var("stg_wuser", {
+		default: null,
+		schema: v.object({ id: v.string() }),
+	});
+	const userWithEmail = v.extend(user, { email: v.string() });
+	const store = v.storage(memoryAdapter(), { user });
+
+	it("a scoped db var re-resolves findOne/create against mounted v.extend", async () => {
+		const db = v.var("stg_wdb", {
+			default: store as typeof store | undefined,
+		});
+		const run = v.fn({ use: [{ user, userWithEmail, db }] }, async (c) => {
+			expectTypeOf(c.stg_wuser)
+				.exclude<null>()
+				.toEqualTypeOf<{ id: string; email: string }>();
+			const created = await c.stg_wdb.user.create({
+				id: "1",
+				email: "a@b.c",
+			});
+			expectTypeOf(created).toEqualTypeOf<{
+				id: string;
+				email: string;
+			}>();
+			const found = await c.stg_wdb.user.findOne({ email: "a@b.c" });
+			expectTypeOf(found).toEqualTypeOf<{
+				id: string;
+				email: string;
+			} | null>();
+			return { found, created };
+		});
+		const out = await run();
+		expect(out.created).toEqual({ id: "1", email: "a@b.c" });
+		expect(out.found).toEqual({ id: "1", email: "a@b.c" });
+	});
+
+	it("use: [{ db }] mounts storage and widens collections the same way", async () => {
+		const run = v.fn(
+			{ use: [{ user, userWithEmail, db: store }] },
+			async (c) => {
+				const found = await c.db.user.findOne({ email: "x@y.z" });
+				expectTypeOf(found).toEqualTypeOf<{
+					id: string;
+					email: string;
+				} | null>();
+				const many = await c.db.user.findMany({ email: "x@y.z" });
+				expectTypeOf(many).toEqualTypeOf<{ id: string; email: string }[]>();
+				const updated = await c.db.user.update({ email: "x@y.z" }, { id: "2" });
+				expectTypeOf(updated).toEqualTypeOf<{
+					id: string;
+					email: string;
+				} | null>();
+				return c.db.user.create({ id: "2", email: "x@y.z" });
+			},
+		);
+		expect(await run()).toEqual({ id: "2", email: "x@y.z" });
+	});
+
+	it("a customized re-export in scope widens collection rows too", async () => {
+		const base = v.var("stg_custom_user", {
+			default: null,
+			schema: v.object({ id: v.string() }),
+		});
+		const full = base.customize({
+			schema: (t) => t.add({ email: t.string() }),
+		});
+		const db = v.storage(memoryAdapter(), { user: base });
+		v.fn({ use: [{ base, full, db }] }, async (c) => {
+			const row = await c.db.user.findOne({ email: "a@b.c" });
+			expectTypeOf(row).toEqualTypeOf<{ id: string; email: string } | null>();
+			const created = await c.db.user.create({ id: "1", email: "a@b.c" });
+			expectTypeOf(created).toEqualTypeOf<{ id: string; email: string }>();
+		});
+	});
+
+	it("a scope mounting nothing on the model leaves Where alone", () => {
+		const plain = v.var("stg_plain_user", {
+			default: null,
+			schema: v.object({ id: v.string() }),
+		});
+		const db = v.storage(memoryAdapter(), { user: plain });
+		v.fn({ use: [{ plain, db }] }, async (c) => {
+			expectTypeOf(c.db.user.findOne).parameter(0).toEqualTypeOf<{
+				id?: string | WhereOps<string>;
+			}>();
+			// @ts-expect-error email is not on the base model
+			await c.db.user.findOne({ email: "nope" });
+		});
 	});
 });

--- a/packages/experimental/src/storage.ts
+++ b/packages/experimental/src/storage.ts
@@ -1,6 +1,6 @@
 import { matchesTarget, type OnEntry } from "./module";
 import { asType, attrsOf, isVar } from "./schema";
-import type { ValueOfVar, VarDefination } from "./var";
+import type { NameOfVar, ValueOfVar, VarDefination } from "./var";
 
 /* ---------------------------------- where ---------------------------------- */
 
@@ -136,8 +136,11 @@ export type FindManyOptions<R> = {
 
 /** One model's CRUD surface. `create` is generic so a row EXTENDED by a
  * mounted module (an account with a password field) keeps its extra
- * fields through the round-trip. */
-export type Collection<R> = {
+ * fields through the round-trip outside a widened scope. Inside a scope
+ * that mounts `v.extend` / same-name customize on the model var, {@link
+ * WidenSchemaFns} rewrites `R` (see `$modelVar`) the same way it widens
+ * `v.fn.type({ input: user })`. */
+export type Collection<R, N extends string = string> = {
 	create: <T extends R>(data: T) => Promise<T>;
 	findOne: (where: Where<R>) => Promise<R | null>;
 	findMany: (where?: Where<R>, options?: FindManyOptions<R>) => Promise<R[]>;
@@ -157,6 +160,13 @@ export type Collection<R> = {
 		where: Where<R>,
 		increments: Partial<Record<keyof R & string, number>>,
 	) => Promise<R | null>;
+	/**
+	 * Phantom: the model var's name. Scope resolution reads it to WIDEN
+	 * `R` with everything the scope mounts on that var - same role as
+	 * `$fnVar` on fn schemas. Optional, so plain collection objects still
+	 * satisfy the type.
+	 */
+	readonly $modelVar?: [N];
 };
 
 /**
@@ -387,6 +397,9 @@ type SchemaOf<T> = T extends { $var: true }
 
 type RowOf<T> = NonNullable<ValueOfVar<SchemaOf<T>>>;
 
+/** Declared name of the var behind a model input - brands the collection. */
+type ModelVarName<T> = NameOfVar<SchemaOf<T>> & string;
+
 export type StorageModels = Record<string, ModelInput>;
 
 export type StorageOp =
@@ -425,8 +438,15 @@ export type StorageTarget<M> =
 	| `*.${StorageOp}`;
 
 export type Storage<M extends StorageModels> = {
-	[K in keyof M]: Collection<RowOf<M[K]>>;
+	[K in keyof M]: Collection<RowOf<M[K]>, ModelVarName<M[K]>>;
 } & StorageApi<M>;
+
+/** Duck-type a storage instance - `$models` plus the `$adapter` method. */
+export const isStorage = (value: unknown): value is Storage<StorageModels> =>
+	typeof value === "object" &&
+	value !== null &&
+	"$models" in value &&
+	typeof (value as { $adapter?: unknown }).$adapter === "function";
 
 /** The customization surface, `$`-prefixed so model keys never collide. */
 export type StorageApi<M extends StorageModels> = {


### PR DESCRIPTION
## Summary

`v.extend` / customize already widened `v.fn.type({ input: user })` call sites in scope, but `v.storage` collections kept `Collection<R>` / `Where<R>` frozen from `makeStorage` time. Mounting `userWithEmail` still left `c.db.user.findOne({ email })` type-erroring on base `{ id }`.

- Brand collections with the model var name (`$modelVar`) and re-resolve row/`Where` types in `WidenSchemaFns` via `RowInScope` / `ResolvedVars` / `VarExtensionsFor`.
- Keep storage opaque in `ModuleFns` / `collectUsable` / `UseApi` so `use: [{ db }]` exposes real collections on `c.db`, then widen them through `ApplyOn` like used fns.
- Document the storage case next to the existing `createUser` fn-schema widening example.