### PR TITLE
feat(experimental): support optional on v.fn.type

### DIFF
--- a/packages/experimental/src/fn.test.ts
+++ b/packages/experimental/src/fn.test.ts
@@ -518,6 +518,33 @@ describe("fn as input schema", () => {
 		);
 	});
 
+	it("v.fn.type({ optional: true }) is omittable in an object shape", () => {
+		const hooks = v.object({
+			onCreate: v.fn.type({
+				input: { id: v.string() },
+				optional: true,
+			}),
+			onDelete: v.fn.type({ input: { id: v.string() } }),
+		});
+		const run = v.fn({ input: hooks }, (c) => {
+			expectTypeOf(c.input.onCreate).toEqualTypeOf<
+				((input: { id: string }) => any) | undefined
+			>();
+			expectTypeOf(c.input.onDelete).toEqualTypeOf<
+				(input: { id: string }) => any
+			>();
+			return c.input.onCreate?.({ id: "1" }) ?? "skipped";
+		});
+		// Required sibling stays required - omit onCreate only.
+		expect(run({ onDelete: () => null })).toBe("skipped");
+		expect(
+			run({
+				onDelete: () => null,
+				onCreate: (i) => i.id,
+			}),
+		).toBe("1");
+	});
+
 	it("customize toolkit carries fn", () => {
 		const base = v.var("fnt_custom", { schema: v.object({}) });
 		const widened = base.customize({

--- a/packages/experimental/src/fn.ts
+++ b/packages/experimental/src/fn.ts
@@ -440,6 +440,9 @@ export interface Fn<
 	 * CAN be validated for - the value is a function, and a plain closure
 	 * gets the declared input checked at its door on every call.
 	 *
+	 * `optional` / `default` work like on `v.string()` etc., so a prop in
+	 * `v.object({...})` can be a fn type and still omittable.
+	 *
 	 * This exists apart from a handler-less `v.fn({ input, output })` for
 	 * INLINE use: `v.fn`'s handler overloads return a callable, which makes
 	 * TypeScript defer any inline `v.fn(...)` call inside another generic
@@ -447,10 +450,22 @@ export interface Fn<
 	 * `v.var` then loses its shape inference entirely. `v.fn.type` returns a
 	 * plain carrier, so it composes inline anywhere.
 	 */
-	readonly type: <I = unknown, O = unknown>(signature?: {
+	readonly type: <
+		I = unknown,
+		O = unknown,
+		D = never,
+		Opt extends boolean = false,
+	>(signature?: {
 		input?: I;
 		output?: O;
-	}) => { readonly $fnSchema: { input?: I; output?: O } };
+		default?: D;
+		optional?: Opt;
+	}) => { readonly $fnSchema: { input?: I; output?: O } } & ([Opt] extends [
+		true,
+	]
+		? { readonly optional: true }
+		: unknown) &
+		([D] extends [never] ? unknown : { readonly default: D });
 
 	/* ---- a handler TERMINATES: these four produce a callable fn ---- */
 	<R>(
@@ -1372,8 +1387,19 @@ const builderFn = (baseKey: string, base: Record<string, any>) => {
 	// (see `isFnSchema`).
 	return Object.assign(build, {
 		$fnSchema: { input: base.input, output: base.output },
-		type: (signature: { input?: unknown; output?: unknown } = {}) => ({
+		type: (
+			signature: {
+				input?: unknown;
+				output?: unknown;
+				optional?: boolean;
+				default?: unknown;
+			} = {},
+		) => ({
 			$fnSchema: { input: signature.input, output: signature.output },
+			...(signature.optional ? { optional: true as const } : {}),
+			...(signature.default !== undefined
+				? { default: signature.default }
+				: {}),
 		}),
 	});
 };

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -237,7 +237,7 @@ export const outputContract = (
 type FieldOut<F> = F extends { $var: true; schema?: infer S }
 	? InferInput<NonNullable<S>>
 	: F extends { $fnSchema: { input?: infer FI; output?: infer FO } }
-		? SchemaFnOut<FI, FO> & FnVarBrand<FI>
+		? FnSchemaOut<F, SchemaFnOut<FI, FO> & FnVarBrand<FI>>
 		: F extends TypeDefination<any, any, any>
 			? OutputOf<F>
 			: F extends Record<string, unknown>
@@ -255,19 +255,36 @@ type FieldIn<F> = F extends { $var: true; schema?: infer S }
 				: never;
 
 /**
+ * `optional: true` on `v.fn.type` widens the same way a type's `optional`
+ * does: absent without a default means the value may be `undefined`.
+ */
+type FnSchemaOut<F, Fn> = F extends { optional: true }
+	? F extends { default: infer _D }
+		? Fn
+		: Fn | undefined
+	: Fn;
+
+/**
  * A field's declared default, looked through a var to its schema. Only a
  * TYPE's default counts - a var's own default is its initial value, not a
  * licence to omit the input. The `$fnSchema` guard mirrors `asType`'s
  * ordering: a bare `v.fn` is CALLABLE, and any callable duck-matches
  * TypeDefination (`.name` comes with every function), which would read a
- * phantom default off it and wrongly mark the field optional.
+ * phantom default off it and wrongly mark the field optional. `v.fn.type`
+ * may still declare `optional` / `default` on the carrier itself.
  */
 type DefaultOf<F> = F extends { $var: true; schema?: infer S }
 	? NonNullable<S> extends TypeDefination<any, any, infer D>
 		? D
 		: never
 	: F extends { $fnSchema: unknown }
-		? never
+		? F extends { optional: true }
+			? F extends { default: infer D }
+				? D
+				: undefined
+			: F extends { default: infer D }
+				? D
+				: never
 		: F extends TypeDefination<any, any, infer D>
 			? D
 			: never;
@@ -318,8 +335,11 @@ export const isType = (value: any): value is TypeDefination<any, any> =>
  * branded too, so bare `v.fn` reads as "any function". */
 export const isFnSchema = (
 	value: any,
-): value is { $fnSchema: { input?: unknown; output?: unknown } } =>
-	typeof value?.$fnSchema === "object" && value.$fnSchema !== null;
+): value is {
+	$fnSchema: { input?: unknown; output?: unknown };
+	optional?: boolean;
+	default?: unknown;
+} => typeof value?.$fnSchema === "object" && value.$fnSchema !== null;
 
 export const asType = (value: any): TypeDefination<any, any> =>
 	// A var's own `name` ("user") would duck-match isType, so unwrap first -
@@ -327,7 +347,12 @@ export const asType = (value: any): TypeDefination<any, any> =>
 	isVar(value)
 		? asType(value.schema ?? {})
 		: isFnSchema(value)
-			? { name: "function", fnInput: value.$fnSchema.input }
+			? ({
+					name: "function",
+					fnInput: value.$fnSchema.input,
+					...(value.optional ? { optional: true } : {}),
+					...(value.default !== undefined ? { default: value.default } : {}),
+				} as TypeDefination<any, any>)
 			: isType(value)
 				? value
 				: { name: "object", shape: value };


### PR DESCRIPTION
## Summary

`v.fn.type` can take `optional` / `default` the same way `v.string()` and the other type constructors do, so a field in `v.object({...})` can be a fn signature and still omittable.

- Carrier keeps `optional` / `default` alongside `$fnSchema`
- `DefaultOf` / `FieldOut` treat those like a normal type's optionality
- `asType` passes them through so runtime validation allows omit