### PR TITLE
feat(experimental): normalize emails during schema validate

### DIFF
--- a/packages/experimental/src/attrs.test.ts
+++ b/packages/experimental/src/attrs.test.ts
@@ -27,7 +27,7 @@ describe("schema $attrs", () => {
 		const email = withAttrs(v.string({ email: true }), "db", {
 			unique: true,
 		});
-		expect(validate(email, "a@b.c", "email")).toBe("a@b.c");
+		expect(validate(email, "a@b.co", "email")).toBe("a@b.co");
 		expect(() => validate(email, "nope", "email")).toThrow(ValidationError);
 	});
 

--- a/packages/experimental/src/schema-dx.test.ts
+++ b/packages/experimental/src/schema-dx.test.ts
@@ -125,3 +125,25 @@ describe("factory defaults", () => {
 		expect(xs).not.toBe(ys);
 	});
 });
+
+describe("email normalization", () => {
+	it("trims and lowercases before validating", () => {
+		const field = v.string({ email: true });
+		expect(validate(field, "  Foo@Bar.COM  ", "email")).toBe("foo@bar.com");
+	});
+
+	it("still rejects malformed addresses after normalize", () => {
+		const field = v.string({ email: true });
+		expect(() => validate(field, "  not-an-email  ", "email")).toThrow(
+			/expected an email address/,
+		);
+	});
+
+	it("user transform receives the normalized value", () => {
+		const field = v.string({
+			email: true,
+			transform: (s) => `user:${s}`,
+		});
+		expect(validate(field, " A@B.CO ", "email")).toBe("user:a@b.co");
+	});
+});

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -9,6 +9,7 @@ export type Rules = {
 	/** Strings only: exact length. */
 	length?: number;
 	regex?: RegExp;
+	/** Strings only. Trims and lowercases before the format check. */
 	email?: boolean;
 	url?: boolean;
 	startsWith?: string;
@@ -428,7 +429,12 @@ export const typeOf = (value: unknown) =>
 
 export const isVar = (value: any): boolean => value?.$var === true;
 
-const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Zod's email regex
+// The author has written about this explicitly: trying to accept every technically valid email address leads to overly complex,
+// hard-to-maintain, and sometimes ReDoS-vulnerable regexes that still reject real-world addresses people actually use.
+// Zod prioritizes a practical filter that works well for the vast majority of real user-entered emails.
+const EMAIL =
+	/^(?!\.)(?!.*\.\.)([a-z0-9_'+\-.]*)[a-z0-9_+-]@([a-z0-9][a-z0-9-]*\.)+[a-z]{2,}$/;
 
 const fail = (path: string, message: string): never => {
 	throw new ValidationError(path, message);
@@ -647,6 +653,11 @@ export const validate = (
 			path,
 			`expected ${def.name}, received ${typeOf(value)}`,
 		);
+	}
+	// Canonicalize before rules so padded / mixed-case addresses pass the
+	// email regex and handlers always see the normalized form.
+	if (def.email && typeof value === "string") {
+		value = value.trim().toLowerCase();
 	}
 	applyRules(def, value, path);
 	return def.transform ? def.transform(value) : value;


### PR DESCRIPTION
## Summary

`email: true` now trims and lowercases the value before the format check, so padded or mixed-case addresses validate and handlers always see a canonical form. Also switches the email regex to Zod's practical filter.