### PR TITLE
fix(experimental): allow partial object defaults with optional

### DIFF
--- a/packages/experimental/src/schema-dx.test.ts
+++ b/packages/experimental/src/schema-dx.test.ts
@@ -44,11 +44,25 @@ describe("other vTypes type-arg + optional DX", () => {
 		>();
 	});
 
+	it("v.number accepts optional: true without a type param", () => {
+		const field = v.number({ optional: true });
+		expectTypeOf<InferOutput<typeof field>>().toEqualTypeOf<
+			number | undefined
+		>();
+	});
+
 	it("v.number with output type param accepts optional: true", () => {
 		const field = v.number<number>({ optional: true });
 		expectTypeOf<InferOutput<typeof field>>().toEqualTypeOf<
 			number | undefined
 		>();
+	});
+
+	it("v.boolean/date accept optional: true", () => {
+		const b = v.boolean({ optional: true });
+		const d = v.date({ optional: true });
+		expectTypeOf<InferOutput<typeof b>>().toEqualTypeOf<boolean | undefined>();
+		expectTypeOf<InferOutput<typeof d>>().toEqualTypeOf<Date | undefined>();
 	});
 
 	it("v.array with element accepts optional: true", () => {
@@ -76,6 +90,57 @@ describe("other vTypes type-arg + optional DX", () => {
 			default: ["5"],
 		});
 		expectTypeOf<InferOutput<typeof arr>>().toEqualTypeOf<number[]>();
+	});
+
+	it("object optional + empty default allows required children", () => {
+		const field = v.object(
+			{
+				password: v.object(
+					{
+						hash: v.string({ optional: true }),
+						verify: v.string({ optional: true }),
+					},
+					{ optional: true, default: {} },
+				),
+				minPasswordLength: v.number(),
+				maxPasswordLength: v.number({ optional: true }),
+			},
+			{ optional: true, default: {} },
+		);
+		expectTypeOf<InferOutput<typeof field>>().toEqualTypeOf<{
+			password: { hash?: string; verify?: string };
+			minPasswordLength: number;
+			maxPasswordLength?: number;
+		}>();
+	});
+
+	it("password-options style extend with required number fields", () => {
+		const options = v.var("options", { schema: v.object({}), default: {} });
+		const passwordOptions = v.extend(options, {
+			emailAndPassword: v.object(
+				{
+					password: v.object(
+						{
+							hash: v.fn.type({
+								input: { password: v.string() },
+								output: v.string(),
+								optional: true,
+							}),
+							verify: v.fn.type({
+								input: { password: v.string(), hash: v.string() },
+								output: v.boolean(),
+								optional: true,
+							}),
+						},
+						{ optional: true, default: {} },
+					),
+					minPasswordLength: v.number(),
+					maxPasswordLength: v.number(),
+				},
+				{ optional: true, default: {} },
+			),
+		});
+		expectTypeOf(passwordOptions).not.toBeNever();
 	});
 });
 

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -47,6 +47,8 @@ export interface TypeDefination<T, O, D = never> extends Rules {
 
 export type TypeOptions<T, O> = {
 	transform?: (value: T) => O;
+	/** Accepted on every helper; overloads refine the output when `true`. */
+	optional?: boolean;
 };
 
 /**
@@ -815,13 +817,20 @@ type AnyFn = {
 	<T = unknown>(options?: TypeOptions<T, T>): TypeDefination<T, T, never>;
 };
 
+/**
+ * Object defaults may be partial: nested fields still run through
+ * validate (so their own defaults apply). An empty `{}` is always
+ * fine at the type level - parent `optional` / `default` must not
+ * demand that every required child be listed in the default.
+ */
+type ObjectDefault<S> = DefaultInput<Partial<ArgsShape<S>>>;
+
 type ObjectFn = {
 	<S, O = DefineOutput<S>>(
 		shape: S,
 		options: TypeOptions<DefineOutput<S>, O> & {
 			optional: true;
-			// Defaults are validated as inputs, so they use ArgsShape.
-			default: DefaultInput<ArgsShape<S>>;
+			default: ObjectDefault<S>;
 		},
 	): TypeDefination<ArgsShape<S>, O, ArgsShape<S>>;
 	<S, O = DefineOutput<S>>(
@@ -831,7 +840,7 @@ type ObjectFn = {
 	<S, O = DefineOutput<S>>(
 		shape: S,
 		options: TypeOptions<DefineOutput<S>, O> & {
-			default: DefaultInput<ArgsShape<S>>;
+			default: ObjectDefault<S>;
 		},
 	): TypeDefination<ArgsShape<S>, O, ArgsShape<S>>;
 	<S, O = DefineOutput<S>>(


### PR DESCRIPTION
## Summary

`v.object(shape, { optional: true, default: {} })` was failing whenever the shape had required fields, and TypeScript blamed `optional` even though the real mismatch was the empty default. Object defaults are now typed as partial inputs, so a parent being optional/defaulted does not force every child to appear in the default.

Also put `optional` on the shared type options so helpers like `v.number({ optional: true })` accept it without falling through to an overload that pretends the property does not exist.