### PR TITLE
fix(experimental): type same-key helpers on merge:true vars

### DIFF
--- a/packages/experimental/src/fn.ts
+++ b/packages/experimental/src/fn.ts
@@ -341,9 +341,63 @@ type UseVarKeys<U> = {
 	[K in keyof U]: U[K] extends VarDefination<any, any, any, any> ? K : never;
 }[keyof U];
 
-/** A var alias' surface: the var's VALUE, read and written in place. */
+/**
+ * VarDefination surface keys. ModuleFns intersects a merge var with
+ * same-key namespace helpers (`VarDef & { createUser }`); stripping these
+ * leaves the helper group for {@link UseApi}.
+ */
+type VarSurfaceKeys =
+	| "$var"
+	| "name"
+	| "default"
+	| "schema"
+	| "type"
+	| "$source"
+	| "$attrs"
+	| "$merge"
+	| "customize";
+
+type MergeHelpersOnVar<V> = Omit<V, VarSurfaceKeys>;
+
+/** Bound helpers intersected onto a merge var in ModuleFns, if any. */
+type UseApiMergeExtras<V> = V extends { $merge: true }
+	? [keyof MergeHelpersOnVar<V>] extends [never]
+		? never
+		: UseApi<MergeHelpersOnVar<V>>
+	: never;
+
+/**
+ * A var alias' surface: the var's VALUE, plus same-key namespace helpers
+ * when the var is `merge: true` (mirrors {@link collectMergeSeeds} /
+ * {@link viewMergeVar}).
+ */
 type UseVarValue<V> =
-	V extends VarDefination<any, infer T, any, any> ? T : never;
+	V extends VarDefination<any, infer T, any, any>
+		? UseApiMergeExtras<V> extends infer H
+			? [H] extends [never]
+				? T
+				: Prettify<T & H>
+			: T
+		: never;
+
+/**
+ * Fold merge-var helpers from the usable map `U` onto scope values keyed
+ * by DECLARED name (so `c.vt_merge_db.byTag` types when the export key
+ * was `db`).
+ */
+type MergeIntoScope<RV, U> = {
+	[K in keyof RV]: HelpersForDeclaredName<K & string, U> extends infer H
+		? [H] extends [never]
+			? RV[K]
+			: Prettify<RV[K] & H>
+		: RV[K];
+};
+
+type HelpersForDeclaredName<N extends string, U> = {
+	[K in keyof U]: U[K] extends VarDefination<N, any, any, any>
+		? UseApiMergeExtras<U[K]>
+		: never;
+}[keyof U];
 
 export type UseApi<U> = Prettify<
 	{
@@ -416,7 +470,12 @@ export type Context<
 	types: typeof vTypes;
 } & /** Every var in scope, directly on `c`: read `c.session`, write by
  * plain assignment (`c.session = {...}`). Every var is a readonly
- * property on a readonly fn. */ VarScope<RV, Required, RO> &
+ * property on a readonly fn. Merge vars also expose same-key helpers
+ * folded from `U` (declared-name access). */ VarScope<
+	MergeIntoScope<RV, U>,
+	Required,
+	RO
+> &
 	/** Fns from `use`, directly on `c` and already threaded with this
 	 * context: `c.createUser({...})`. */
 	(RO extends true ? ReadUseApi<U> : UseApi<U>);

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -14,21 +14,28 @@ import {
 
 interface V {
 	fn: Fn;
-	var: <N extends LiteralString, S = undefined, D = undefined>(
+	var: <
+		N extends LiteralString,
+		S = undefined,
+		D = undefined,
+		const M extends boolean | undefined = undefined,
+	>(
 		name: N,
-		options?: { default?: D; schema?: S; merge?: boolean },
+		options?: { default?: D; schema?: S; merge?: M },
 		// A default the schema already covers (e.g. `{}` against an
 		// all-optional shape) is absorbed; `default: null` still unions in.
 		// `merge: true` - object contributions from `use` modules (same-name
 		// defaults, same-key namespaces) shallow-merge onto the value;
-		// writes accumulate the same way.
+		// writes accumulate the same way. Brand `$merge: true` so scope
+		// types can fold those helpers onto the var.
 	) => VarDefination<
 		N,
 		[S] extends [undefined]
 			? D
 			: InferInput<S> | ([D] extends [InferInput<S>] ? never : D),
 		S
-	>;
+	> &
+		(M extends true ? { $merge: true } : unknown);
 	/** A var you accumulate into: `set()` merges instead of replacing. */
 	record: <N extends LiteralString, S = undefined>(
 		name: N,

--- a/packages/experimental/src/var.test.ts
+++ b/packages/experimental/src/var.test.ts
@@ -165,8 +165,48 @@ describe("merge vars", () => {
 			{
 				use: [{ obj: base }, { obj: { who: first } }, { obj: { who: second } }],
 			},
-			(c) => c.vt_merge_obj.who(),
+			// Conflicting same-key helpers collapse to `never` under
+			// UnionToIntersection; runtime still last-wins via collectMergeSeeds.
+			(c) => (c.vt_merge_obj as { who: () => string }).who(),
 		);
 		expect(entry()).toBe("second");
+	});
+
+	it("same-key namespace helpers are typed on the merge var", async () => {
+		const db = v.var("db", {
+			merge: true,
+			default: { storage: true as const },
+		});
+		const createUser = v.fn(
+			"db.create_user",
+			{
+				input: { id: v.string() },
+				output: v.object({ id: v.string() }),
+			},
+			(c) => c.input,
+		);
+		const e = v.fn("auth.", {
+			use: [{ db }, { db: { createUser } }] as const,
+		});
+		const signUp = e.fn("sign_up", async (c) => {
+			expectTypeOf(c.db).toHaveProperty("storage");
+			expectTypeOf(c.db).toHaveProperty("createUser");
+			expectTypeOf(c.db.createUser).toBeCallableWith({ id: "1" });
+			return c.db.createUser({ id: "1" });
+		});
+		await expect(signUp()).resolves.toEqual({ id: "1" });
+	});
+
+	it("helpers are typed on the declared name when export key differs", async () => {
+		const store = v.var("vt_alias_db", {
+			merge: true,
+			default: { storage: true as const },
+		});
+		const ping = v.fn("vt.alias.ping", () => "pong" as const);
+		v.fn({ use: [{ db: store }, { db: { ping } }] as const }, (c) => {
+			expectTypeOf(c.vt_alias_db).toHaveProperty("ping");
+			expectTypeOf(c.db).toHaveProperty("ping");
+			return c.vt_alias_db.ping();
+		});
 	});
 });

--- a/packages/experimental/src/var.ts
+++ b/packages/experimental/src/var.ts
@@ -35,8 +35,10 @@ export interface VarDefination<
 	 * Object contributions from `use` modules merge instead of replacing:
 	 * same-name var defaults and same-export-key namespaces shallow-merge
 	 * onto this value (storage default + helpers). Writes accumulate too.
+	 * `v.var(..., { merge: true })` brands this as `true` so context types
+	 * fold same-key helpers onto the value.
 	 */
-	$merge?: boolean;
+	$merge?: true | boolean;
 	customize: <S>(options: {
 		schema: (v: VarCustomizer<T>) => S;
 	}) => VarDefination<N, InferInput<S>, S>;


### PR DESCRIPTION
ModuleFns already intersected merge vars with namespace helpers, but UseApi collapsed those keys to the default value and ScopeOf never folded helpers onto the declared-name slot.