### PR TITLE
fix(experimental): widen var-bound inputs from parent scope and customize

### DIFF
--- a/packages/experimental/src/fn.ts
+++ b/packages/experimental/src/fn.ts
@@ -281,6 +281,25 @@ export type WidenedArgs<I, ExtPL> =
 					InputVarExtra<ExtPL, I>
 			>;
 
+/** Full module chain a builder has accumulated - parent scopes first. */
+type ChainPL<
+	BasePL extends readonly Module[],
+	PL extends readonly Module[],
+> = readonly [...BasePL, ...PL];
+
+/**
+ * Used fns / groups as the call site sees them: every usable from this
+ * `use` and the builder chain, rewritten with extensions + customize
+ * shadows from the FULL parent chain (not just the child `use`).
+ * `ModuleFns<PL> & BaseFns` collapses correctly when `BaseFns` is still
+ * `unknown` on a fresh builder.
+ */
+type UsableInScope<
+	BaseFns,
+	PL extends readonly Module[],
+	BasePL extends readonly Module[],
+> = ApplyOns<ModuleFns<PL> & BaseFns, ChainPL<BasePL, PL>>;
+
 export type OptionType<
 	I,
 	O,
@@ -620,29 +639,29 @@ export interface Fn<
 		fn: (
 			ctx: Context<
 				I,
-				ScopeOf<PL, Base, readonly [...BasePL, ...PL]>,
+				ScopeOf<PL, Base, ChainPL<BasePL, PL>>,
 				WithDerived<PL, BasePL, Q[number]>,
-				ApplyOns<ModuleFns<PL>, PL> & BaseFns,
+				UsableInScope<BaseFns, PL, BasePL>,
 				Fn<
 					Base & ResolvedVars<PL>,
-					ApplyOns<ModuleFns<PL>, PL> & BaseFns,
-					readonly [...BasePL, ...PL],
+					UsableInScope<BaseFns, PL, BasePL>,
+					ChainPL<BasePL, PL>,
 					Prefix
 				>,
 				RO,
 				Er,
-				readonly [...BasePL, ...PL]
+				ChainPL<BasePL, PL>
 			>,
 		) => R,
 	): PublicFn<
-		WidenedArgs<I, readonly [...BasePL, ...PL]>,
+		WidenedArgs<I, ChainPL<BasePL, PL>>,
 		R,
 		Prefix extends "" ? string : Prefix,
 		I,
 		P,
 		Er,
-		ScopeOf<PL, Base, readonly [...BasePL, ...PL]>,
-		ApplyOns<ModuleFns<PL>, PL> & BaseFns,
+		ScopeOf<PL, Base, ChainPL<BasePL, PL>>,
+		UsableInScope<BaseFns, PL, BasePL>,
 		O
 	>;
 	<
@@ -661,29 +680,29 @@ export interface Fn<
 		fn: (
 			ctx: Context<
 				I,
-				ScopeOf<PL, Base, readonly [...BasePL, ...PL]>,
+				ScopeOf<PL, Base, ChainPL<BasePL, PL>>,
 				WithDerived<PL, BasePL, Q[number]>,
-				ApplyOns<ModuleFns<PL>, PL> & BaseFns,
+				UsableInScope<BaseFns, PL, BasePL>,
 				Fn<
 					Base & ResolvedVars<PL>,
-					ApplyOns<ModuleFns<PL>, PL> & BaseFns,
-					readonly [...BasePL, ...PL],
+					UsableInScope<BaseFns, PL, BasePL>,
+					ChainPL<BasePL, PL>,
 					`${Prefix}${K}`
 				>,
 				RO,
 				Er,
-				readonly [...BasePL, ...PL]
+				ChainPL<BasePL, PL>
 			>,
 		) => R,
 	): PublicFn<
-		WidenedArgs<I, readonly [...BasePL, ...PL]>,
+		WidenedArgs<I, ChainPL<BasePL, PL>>,
 		R,
 		`${Prefix}${K}`,
 		I,
 		P,
 		Er,
-		ScopeOf<PL, Base, readonly [...BasePL, ...PL]>,
-		ApplyOns<ModuleFns<PL>, PL> & BaseFns,
+		ScopeOf<PL, Base, ChainPL<BasePL, PL>>,
+		UsableInScope<BaseFns, PL, BasePL>,
 		O
 	>;
 
@@ -702,8 +721,8 @@ export interface Fn<
 		options: OptionType<I, O, P, Q, PL>,
 	): Instance<
 		Base & ResolvedVars<PL>,
-		BaseFns & ApplyOns<ModuleFns<PL>, PL>,
-		readonly [...BasePL, ...PL],
+		UsableInScope<BaseFns, PL, BasePL>,
+		ChainPL<BasePL, PL>,
 		Prefix,
 		I,
 		O
@@ -720,8 +739,8 @@ export interface Fn<
 		options: OptionType<I, O, P, Q, PL>,
 	): Instance<
 		Base & ResolvedVars<PL>,
-		BaseFns & ApplyOns<ModuleFns<PL>, PL>,
-		readonly [...BasePL, ...PL],
+		UsableInScope<BaseFns, PL, BasePL>,
+		ChainPL<BasePL, PL>,
 		`${Prefix}${K}`,
 		I,
 		O
@@ -753,14 +772,27 @@ const defineFn = (
 	// Interceptors and var extensions this fn brings, from its modules -
 	// nested GROUPS included. The SAME entry mounted twice (two views of
 	// one storage, a module and its re-export) applies once - identity
-	// dedup, like inheritance.
+	// dedup, like inheritance. Same-name `customize` re-exports are
+	// folded in as synthetic extensions so var-bound input re-validates
+	// against the shadowed schema (matching {@link VarArgsInScope}).
 	const own: OnEntry<string>[] = [];
 	const ownExts: VarExtension<string, any>[] = [];
+	const seenVarShadows = new Set<unknown>();
 	const scanMembers = (mod: Record<string, unknown>) => {
 		for (const value of Object.values(mod)) {
 			if (isOn(value) && !own.includes(value)) own.push(value);
 			else if (isVarExtension(value)) ownExts.push(value);
-			else if (isNamespace(value)) scanMembers(value);
+			else if (isVar(value)) {
+				const schema = (value as { schema?: unknown }).schema;
+				if (schema === undefined || seenVarShadows.has(value)) continue;
+				seenVarShadows.add(value);
+				ownExts.push({
+					$varExtend: true,
+					name: (value as { name: string }).name,
+					schema,
+					base: value as never,
+				});
+			} else if (isNamespace(value)) scanMembers(value);
 		}
 	};
 	for (const mod of modules) scanMembers(mod);

--- a/packages/experimental/src/module.ts
+++ b/packages/experimental/src/module.ts
@@ -646,6 +646,25 @@ export type VarArgsInScope<PL, K extends string> = VarExtensionArgsFor<PL, K> &
 		? unknown
 		: UnionToIntersection<VarShadowArgsEntry<Members<PL>, K>>);
 
+/** Parsed-side counterpart of {@link VarArgsInScope}: `v.extend` fields
+ * plus every same-name var declaration's `InferInput` (customize shadows). */
+type VarShadowValueEntry<M, K extends string> = M extends unknown
+	? {
+			[P in keyof M]: M[P] extends VarDefination<K, any, infer S, any>
+				? unknown extends S
+					? never
+					: [NonNullable<S>] extends [never]
+						? never
+						: InferInput<NonNullable<S>>
+				: never;
+		}[keyof M]
+	: never;
+
+export type VarValuesInScope<PL, K extends string> = VarExtensionsFor<PL, K> &
+	([VarShadowValueEntry<Members<PL>, K>] extends [never]
+		? unknown
+		: UnionToIntersection<VarShadowValueEntry<Members<PL>, K>>);
+
 type VarFieldKeys<I> = {
 	[K in keyof I]: I[K] extends { $var: true } ? K : never;
 }[keyof I];
@@ -656,14 +675,16 @@ type VarFields<I> = Exclude<VarFieldKeys<I>, undefined>;
 
 /**
  * Extra args a fn must accept because its INPUT references vars that `PL`
- * extends. Whole-var input (`input: user`) merges at the top level; a var
- * used as a field widens that field. `unknown` when nothing applies.
+ * mutates - `v.extend` and same-name `customize` shadows (see
+ * {@link VarArgsInScope}). Whole-var input (`input: user`) merges at the
+ * top level; a var used as a field widens that field. `unknown` when
+ * nothing applies.
  */
 export type InputVarExtra<PL, I> = I extends {
 	$var: true;
 	name: infer N extends string;
 }
-	? VarExtensionArgsFor<PL, N>
+	? VarArgsInScope<PL, N>
 	: [VarFields<I>] extends [never]
 		? unknown
 		: {
@@ -673,19 +694,20 @@ export type InputVarExtra<PL, I> = I extends {
 					$var: true;
 					name: infer N extends string;
 				}
-					? VarExtensionArgsFor<PL, N>
+					? VarArgsInScope<PL, N>
 					: unknown;
 			};
 
 /**
  * Same merge as {@link InputVarExtra}, on the PARSED side - what the
- * handler sees on `c.input` after mounted extensions have been applied.
+ * handler sees on `c.input` after mounted extensions / customize shadows
+ * have been applied.
  */
 export type InputVarExtraOut<PL, I> = I extends {
 	$var: true;
 	name: infer N extends string;
 }
-	? VarExtensionsFor<PL, N>
+	? VarValuesInScope<PL, N>
 	: [VarFields<I>] extends [never]
 		? unknown
 		: {
@@ -695,7 +717,7 @@ export type InputVarExtraOut<PL, I> = I extends {
 					$var: true;
 					name: infer N extends string;
 				}
-					? VarExtensionsFor<PL, N>
+					? VarValuesInScope<PL, N>
 					: unknown;
 			};
 
@@ -721,10 +743,11 @@ export type ExtendedArgs<PL, K extends string> = UnionToIntersection<
 /**
  * Rewrite a fn's type with the input extensions the module set `PL`
  * mounts on it. This is how a plugin's extra field becomes REQUIRED at
- * the call site, even though the fn itself never declared it. Storage
- * members get the same scope rewrite as a db var's value ({@link
- * WidenSchemaFns}): collections re-resolve row/`Where` types against
- * mounted `v.extend` / customize.
+ * the call site, even though the fn itself never declared it. Var-bound
+ * inputs also pick up `v.extend` / same-name `customize` via
+ * {@link InputVarExtra}. Storage members get the same scope rewrite as a
+ * db var's value ({@link WidenSchemaFns}): collections re-resolve
+ * row/`Where` types against mounted `v.extend` / customize.
  */
 export type ApplyOn<F, PL> = F extends StorageLike
 	? WidenSchemaFns<F, PL>

--- a/packages/experimental/src/var.test.ts
+++ b/packages/experimental/src/var.test.ts
@@ -105,6 +105,77 @@ describe("var extensions", () => {
 		expectTypeOf(f).parameter(0).toEqualTypeOf<{ id: string; tag: string }>();
 		expect(f({ id: "b", tag: "gold" })).toEqual({ id: "b", tag: "gold" });
 	});
+
+	it("a customized re-export widens a declaring fn's var-bound input", () => {
+		const accountFull = account.customize({
+			schema: (t) => t.add({ tag: t.string() }),
+		});
+		const f = v.fn({ input: account, use: [{ account, accountFull }] }, (c) => {
+			expectTypeOf(c.input).toEqualTypeOf<{ id: string; tag: string }>();
+			return c.input;
+		});
+		expectTypeOf(f).parameter(0).toEqualTypeOf<{ id: string; tag: string }>();
+		expect(f({ id: "c", tag: "pro" })).toEqual({ id: "c", tag: "pro" });
+		// @ts-expect-error tag required once accountFull is mounted
+		expect(() => f({ id: "c" })).toThrow(/vt_account/);
+	});
+
+	it("parent-mounted extensions widen a used endpoint defined earlier", () => {
+		const create = v.fn(
+			"vt.create_account",
+			{ input: account, use: [{ account }] },
+			(c) => c.input,
+		);
+		const flat = v.fn({ use: [{ create, withTag }] }, (c) => {
+			expectTypeOf(c.create)
+				.parameter(0)
+				.toEqualTypeOf<{ id: string; tag: string }>();
+			return c.create({ id: "d", tag: "flat" });
+		});
+		expect(flat()).toEqual({ id: "d", tag: "flat" });
+		expect(() =>
+			v.fn({ use: [{ create, withTag }] }, (c) =>
+				c.create({ id: "d" } as never),
+			)(),
+		).toThrow(/vt_account/);
+
+		const builder = v.fn({ use: [{ withTag }] });
+		const nested = builder.fn({ use: [{ create }] }, (c) => {
+			expectTypeOf(c.create)
+				.parameter(0)
+				.toEqualTypeOf<{ id: string; tag: string }>();
+			return c.create({ id: "e", tag: "nested" });
+		});
+		expect(nested()).toEqual({ id: "e", tag: "nested" });
+		expect(() =>
+			builder.fn({ use: [{ create }] }, (c) =>
+				c.create({ id: "e" } as never),
+			)(),
+		).toThrow(/vt_account/);
+	});
+
+	it("parent-mounted customize widens a used endpoint the same way", () => {
+		const accountFull = account.customize({
+			schema: (t) => t.add({ tag: t.string() }),
+		});
+		const create = v.fn(
+			"vt.create_account_full",
+			{ input: account, use: [{ account }] },
+			(c) => c.input,
+		);
+		const run = v.fn({ use: [{ create, accountFull }] }, (c) => {
+			expectTypeOf(c.create)
+				.parameter(0)
+				.toEqualTypeOf<{ id: string; tag: string }>();
+			return c.create({ id: "f", tag: "custom" });
+		});
+		expect(run()).toEqual({ id: "f", tag: "custom" });
+		expect(() =>
+			v.fn({ use: [{ create, accountFull }] }, (c) =>
+				c.create({ id: "f" } as never),
+			)(),
+		).toThrow(/vt_account/);
+	});
 });
 
 describe("record vars", () => {


### PR DESCRIPTION
Used endpoints defined against a base var should pick up later parent-mounted v.extend and customize shadows at both the type and validation layers.