### PR TITLE
feat(experimental): add http.readonly and http.returned field attrs

### DIFF
--- a/packages/experimental/src/attrs.test.ts
+++ b/packages/experimental/src/attrs.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { ValidationError } from "./error";
 import { v } from "./index";
-import { attrsOf, validate, withAttrs } from "./schema";
+import {
+	asType,
+	attrsOf,
+	omitFields,
+	parseFields,
+	rejectFields,
+	validate,
+	withAttrs,
+} from "./schema";
 
 describe("schema $attrs", () => {
 	it("withAttrs merges within a namespace and isolates namespaces", () => {
@@ -59,5 +67,71 @@ describe("schema $attrs", () => {
 		expect(
 			(widened.schema as { shape: Record<string, unknown> }).shape.role,
 		).toBeDefined();
+	});
+});
+
+describe("omitFields / rejectFields / parseFields", () => {
+	const dropMarked = (schema: unknown) =>
+		attrsOf(schema, "http")?.readonly === true;
+	const shape = v.object({
+		id: v.string(),
+		role: withAttrs(v.string(), "http", { readonly: true }),
+		meta: v.object({
+			note: v.string(),
+			secret: withAttrs(v.string(), "http", { readonly: true }),
+		}),
+	});
+
+	it("omitFields projects nested objects", () => {
+		const projected = asType(omitFields(shape, dropMarked));
+		expect(Object.keys(projected.shape as object).sort()).toEqual([
+			"id",
+			"meta",
+		]);
+		const meta = asType((projected.shape as Record<string, unknown>).meta);
+		expect(Object.keys(meta.shape as object)).toEqual(["note"]);
+	});
+
+	it("rejectFields throws on smuggled keys", () => {
+		expect(() =>
+			rejectFields(shape, { id: "1", role: "admin" }, dropMarked),
+		).toThrow(ValidationError);
+		expect(() =>
+			rejectFields(
+				shape,
+				{ id: "1", meta: { note: "n", secret: "s" } },
+				dropMarked,
+			),
+		).toThrow(/field is not allowed/);
+	});
+
+	it("parseFields rejects then validates the projection", () => {
+		expect(
+			parseFields(
+				shape,
+				{ id: "1", meta: { note: "hi" } },
+				{ reject: dropMarked, omit: dropMarked },
+			),
+		).toEqual({ id: "1", meta: { note: "hi" } });
+		expect(() =>
+			parseFields(
+				shape,
+				{ id: "1", role: "admin" },
+				{ reject: dropMarked, omit: dropMarked },
+			),
+		).toThrow(ValidationError);
+	});
+
+	it("omitFields projects through a var schema", () => {
+		const user = v.var("parse_user", {
+			schema: shape,
+		});
+		const projected = omitFields(user, dropMarked);
+		expect(projected.$var).toBe(true);
+		expect(
+			Object.keys(
+				asType((projected as { schema: unknown }).schema).shape as object,
+			).sort(),
+		).toEqual(["id", "meta"]);
 	});
 });

--- a/packages/experimental/src/capability.ts
+++ b/packages/experimental/src/capability.ts
@@ -570,7 +570,7 @@ export const serve = async (
 			// quietly).
 			const inputSchema = (target as FnDefination<any, any>).$schema?.input;
 			if (inputSchema !== undefined) {
-				rejectServerOnly(inputSchema, c.input.input, c.input.call);
+				await rejectServerOnly(inputSchema, c.input.input, c.input.call);
 			}
 			return (target as (i: unknown, p: unknown) => unknown)(c.input.input, c);
 		},

--- a/packages/experimental/src/capability.ts
+++ b/packages/experimental/src/capability.ts
@@ -565,8 +565,9 @@ export const serve = async (
 				const held = await spend(token);
 				c.capability = { ...held, entry: c.input.call };
 			}
-			// Wire edge: reject http.serverOnly fields before the target
-			// validates (object validate would otherwise strip them quietly).
+			// Wire edge: reject http.readonly / serverOnly fields before the
+			// target validates (object validate would otherwise strip them
+			// quietly).
 			const inputSchema = (target as FnDefination<any, any>).$schema?.input;
 			if (inputSchema !== undefined) {
 				rejectServerOnly(inputSchema, c.input.input, c.input.call);

--- a/packages/experimental/src/fn.test.ts
+++ b/packages/experimental/src/fn.test.ts
@@ -65,6 +65,21 @@ describe("v.fn call forms", () => {
 		expect(make({ ok: true })()).toEqual({ ok: true });
 		expect(() => make({ ok: "nope" })()).toThrow(/fnt\.split\.output/);
 	});
+
+	it("http.returned fields are stripped from output validation", async () => {
+		const { returned } = await import("./plugins/http/attrs");
+		const user = v.var("fnt_returned_user", {
+			schema: v.object({
+				id: v.string(),
+				password: returned(v.string()),
+			}),
+		});
+		const f = v.fn("fnt.returned", { output: user }, () => ({
+			id: "1",
+			password: "secret",
+		}));
+		expect(f()).toEqual({ id: "1" });
+	});
 });
 
 describe("omittable input", () => {

--- a/packages/experimental/src/fn.ts
+++ b/packages/experimental/src/fn.ts
@@ -30,10 +30,12 @@ import {
 } from "./module";
 import {
 	asType,
+	attrsOf,
 	type InferArgs,
 	type InferInput,
 	isVar,
 	type OutputSchemaOf,
+	omitFields,
 	outputContract,
 	type TypeDefination,
 	validate,
@@ -813,7 +815,17 @@ const defineFn = (
 
 	// Only the VALIDATION half of the output contract is checked on exit -
 	// a `{ def }`-only output is a documented promise, never a check.
-	const outputValidation = outputContract(options.output).validation;
+	// Fields marked `http.returned` are projected out so they never leave
+	// the process through this fn's result (direct in-process data on the
+	// handler's locals is unaffected).
+	const rawOutputValidation = outputContract(options.output).validation;
+	const outputValidation =
+		rawOutputValidation === undefined
+			? undefined
+			: omitFields(
+					rawOutputValidation,
+					(field) => attrsOf(field, "http")?.returned === true,
+				);
 	const errorTypes = declaredErrors
 		? Object.fromEntries(
 				Object.entries(declaredErrors).map(([tag, schema]) => [
@@ -1196,8 +1208,10 @@ const defineFn = (
 			);
 
 			// Exit contracts run after the body, whether or not it was async.
+			// Output validation both checks AND projects (so `http.returned`
+			// fields / undeclared keys leave through the validated shape).
 			const finish = (result: unknown) => {
-				const afterOutput = () => {
+				const afterOutput = (out: unknown) => {
 					if (bodyRan) {
 						for (const name of options.provides ?? []) {
 							if (missing(name)) {
@@ -1208,9 +1222,9 @@ const defineFn = (
 							}
 						}
 					}
-					return result;
+					return out;
 				};
-				if (outputValidation === undefined) return afterOutput();
+				if (outputValidation === undefined) return afterOutput(result);
 				return thenMaybe(
 					validate(asType(outputValidation), result, `${key}.output`),
 					afterOutput,

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -145,10 +145,15 @@ export {
 export {
 	type AttrBag,
 	attrsOf,
+	type FieldPred,
 	type InferArgs,
 	type InferInput,
 	type InferOutput,
 	type InferType,
+	omitFields,
+	type ParseFieldsOptions,
+	parseFields,
+	rejectFields,
 	type TypeDefination,
 	withAttrs,
 } from "./schema";

--- a/packages/experimental/src/plugins/http/attrs.test.ts
+++ b/packages/experimental/src/plugins/http/attrs.test.ts
@@ -218,4 +218,24 @@ describe("http field attrs", () => {
 			wireInput(schema, { kind: "user", id: "1", role: "admin" }),
 		).toThrow(/readonly field/);
 	});
+
+	it("union arm selection uses the full schema, not the projection", () => {
+		// Earlier arm gates `role` but only accepts numbers; later arm
+		// accepts the string the client sent. Projecting `role` out would
+		// wrongly pick the first arm and reject.
+		const schema = v.union([
+			v.object({
+				kind: v.string({ enum: ["a"] }),
+				role: readonly(v.number()),
+			}),
+			v.object({
+				kind: v.string({ enum: ["a"] }),
+				role: v.string(),
+			}),
+		]);
+		expect(wireInput(schema, { kind: "a", role: "admin" })).toEqual({
+			kind: "a",
+			role: "admin",
+		});
+	});
 });

--- a/packages/experimental/src/plugins/http/attrs.test.ts
+++ b/packages/experimental/src/plugins/http/attrs.test.ts
@@ -196,4 +196,26 @@ describe("http field attrs", () => {
 			id: "1",
 		});
 	});
+
+	it("rejectReadonly only gates the matching union arm", () => {
+		const schema = v.union([
+			v.object({
+				kind: v.string({ enum: ["user"] }),
+				id: v.string(),
+				role: readonly(v.string()),
+			}),
+			v.object({
+				kind: v.string({ enum: ["anon"] }),
+				token: v.string(),
+				role: v.string({ optional: true }),
+			}),
+		]);
+		// `role` is readonly on the user arm only; anon may still send it.
+		expect(
+			wireInput(schema, { kind: "anon", token: "t", role: "guest" }),
+		).toEqual({ kind: "anon", token: "t", role: "guest" });
+		expect(() =>
+			wireInput(schema, { kind: "user", id: "1", role: "admin" }),
+		).toThrow(/readonly field/);
+	});
 });

--- a/packages/experimental/src/plugins/http/attrs.test.ts
+++ b/packages/experimental/src/plugins/http/attrs.test.ts
@@ -238,4 +238,17 @@ describe("http field attrs", () => {
 			role: "admin",
 		});
 	});
+
+	it("wrong-typed readonly keys still reject on projected fallback", () => {
+		const schema = v.union([
+			v.object({
+				kind: v.string({ enum: ["user"] }),
+				id: v.string(),
+				role: readonly(v.string()),
+			}),
+		]);
+		expect(() =>
+			wireInput(schema, { kind: "user", id: "1", role: 123 as never }),
+		).toThrow(/readonly field/);
+	});
 });

--- a/packages/experimental/src/plugins/http/attrs.test.ts
+++ b/packages/experimental/src/plugins/http/attrs.test.ts
@@ -251,4 +251,20 @@ describe("http field attrs", () => {
 			wireInput(schema, { kind: "user", id: "1", role: 123 as never }),
 		).toThrow(/readonly field/);
 	});
+
+	it("nested unions reject wrong-typed readonly keys too", () => {
+		const schema = v.object({
+			profile: v.union([
+				v.object({
+					kind: v.string({ enum: ["user"] }),
+					role: readonly(v.string()),
+				}),
+			]),
+		});
+		expect(() =>
+			wireInput(schema, {
+				profile: { kind: "user", role: 123 as never },
+			}),
+		).toThrow(/readonly field/);
+	});
 });

--- a/packages/experimental/src/plugins/http/attrs.test.ts
+++ b/packages/experimental/src/plugins/http/attrs.test.ts
@@ -5,7 +5,10 @@ import { asType, attrsOf, validate } from "../../schema";
 import {
 	clientSchema,
 	fromJsonBody,
-	rejectServerOnly,
+	readonly,
+	rejectReadonly,
+	responseSchema,
+	returned,
 	serverOnly,
 	wireInput,
 } from "./attrs";
@@ -13,71 +16,112 @@ import {
 describe("http field attrs", () => {
 	const shape = {
 		id: v.string(),
-		role: serverOnly(v.string()),
+		role: readonly(v.string()),
+		password: returned(v.string()),
 		meta: v.object({
 			note: v.string(),
-			secret: serverOnly(v.string()),
+			secret: readonly(v.string()),
+			hash: returned(v.string()),
 		}),
 	};
 
-	it("serverOnly writes $attrs.http", () => {
+	it("readonly and returned write $attrs.http", () => {
+		expect(attrsOf(readonly(v.string()), "http")).toEqual({
+			readonly: true,
+		});
+		expect(attrsOf(returned(v.string()), "http")).toEqual({
+			returned: true,
+		});
 		expect(attrsOf(serverOnly(v.string()), "http")).toEqual({
 			serverOnly: true,
 		});
 	});
 
-	it("clientSchema drops server-only fields nested", () => {
+	it("clientSchema drops readonly fields nested", () => {
 		const projected = asType(clientSchema(v.object(shape)));
 		expect(Object.keys(projected.shape as object).sort()).toEqual([
 			"id",
 			"meta",
+			"password",
 		]);
 		const meta = asType((projected.shape as Record<string, unknown>).meta);
-		expect(Object.keys(meta.shape as object)).toEqual(["note"]);
+		expect(Object.keys(meta.shape as object).sort()).toEqual(["hash", "note"]);
 	});
 
-	it("rejectServerOnly fails when a server-only key is present", () => {
+	it("responseSchema drops returned fields nested", () => {
+		const projected = asType(responseSchema(v.object(shape)));
+		expect(Object.keys(projected.shape as object).sort()).toEqual([
+			"id",
+			"meta",
+			"role",
+		]);
+		const meta = asType((projected.shape as Record<string, unknown>).meta);
+		expect(Object.keys(meta.shape as object).sort()).toEqual([
+			"note",
+			"secret",
+		]);
+	});
+
+	it("rejectReadonly fails when a readonly key is present", () => {
 		expect(() =>
-			rejectServerOnly(v.object(shape), {
+			rejectReadonly(v.object(shape), {
 				id: "1",
 				role: "admin",
 			}),
 		).toThrow(ValidationError);
 		expect(() =>
-			rejectServerOnly(v.object(shape), {
+			rejectReadonly(v.object(shape), {
 				id: "1",
 				meta: { note: "hi", secret: "x" },
 			}),
-		).toThrow(/server-only/);
+		).toThrow(/readonly field/);
 	});
 
-	it("wireInput accepts client fields and rejects smuggled server-only", () => {
+	it("wireInput accepts client fields and rejects smuggled readonly", () => {
 		expect(
 			wireInput(v.object(shape), {
 				id: "1",
-				meta: { note: "hi" },
+				password: "secret",
+				meta: { note: "hi", hash: "h" },
 			}),
-		).toEqual({ id: "1", meta: { note: "hi" } });
+		).toEqual({
+			id: "1",
+			password: "secret",
+			meta: { note: "hi", hash: "h" },
+		});
 		expect(() =>
 			wireInput(v.object(shape), { id: "1", role: "admin" }),
 		).toThrow(ValidationError);
 	});
 
-	it("in-process validate still accepts server-only fields", () => {
+	it("serverOnly still gates the wire like readonly", () => {
+		const schema = v.object({
+			id: v.string(),
+			role: serverOnly(v.string()),
+		});
+		expect(() => wireInput(schema, { id: "1", role: "admin" })).toThrow(
+			/readonly field/,
+		);
+		expect(wireInput(schema, { id: "1" })).toEqual({ id: "1" });
+	});
+
+	it("in-process validate still accepts readonly fields", () => {
 		expect(
 			validate(
 				asType(v.object(shape)),
 				{
 					id: "1",
 					role: "admin",
-					meta: { note: "n", secret: "s" },
+					password: "p",
+					meta: { note: "n", secret: "s", hash: "h" },
 				},
 				"user",
 			),
 		).toEqual({
 			id: "1",
 			role: "admin",
-			meta: { note: "n", secret: "s" },
+			password: "p",
+			meta: { note: "n", secret: "s", hash: "h" },
 		});
 	});
 
@@ -85,11 +129,16 @@ describe("http field attrs", () => {
 		const request = new Request("https://example.com", {
 			method: "POST",
 			headers: { "content-type": "application/json" },
-			body: JSON.stringify({ id: "1", meta: { note: "ok" } }),
+			body: JSON.stringify({
+				id: "1",
+				password: "p",
+				meta: { note: "ok", hash: "h" },
+			}),
 		});
 		await expect(fromJsonBody(request, v.object(shape))).resolves.toEqual({
 			id: "1",
-			meta: { note: "ok" },
+			password: "p",
+			meta: { note: "ok", hash: "h" },
 		});
 
 		const smuggle = new Request("https://example.com", {
@@ -111,12 +160,12 @@ describe("http field attrs", () => {
 		);
 	});
 
-	it("clientSchema and rejectServerOnly recurse into union arms", () => {
+	it("clientSchema and rejectReadonly recurse into union arms", () => {
 		const schema = v.union([
 			v.object({
 				kind: v.string({ enum: ["user"] }),
 				id: v.string(),
-				role: serverOnly(v.string()),
+				role: readonly(v.string()),
 			}),
 			v.object({
 				kind: v.string({ enum: ["anon"] }),
@@ -136,8 +185,8 @@ describe("http field attrs", () => {
 		]);
 
 		expect(() =>
-			rejectServerOnly(schema, { kind: "user", id: "1", role: "admin" }),
-		).toThrow(/server-only/);
+			rejectReadonly(schema, { kind: "user", id: "1", role: "admin" }),
+		).toThrow(/readonly field/);
 		expect(wireInput(schema, { kind: "anon", token: "t" })).toEqual({
 			kind: "anon",
 			token: "t",

--- a/packages/experimental/src/plugins/http/attrs.ts
+++ b/packages/experimental/src/plugins/http/attrs.ts
@@ -1,115 +1,86 @@
 import { ValidationError } from "../../error";
 import {
-	asType,
 	attrsOf,
-	isVar,
-	typeOf,
-	validate,
+	omitFields,
+	parseFields,
+	rejectFields,
 	withAttrs,
 } from "../../schema";
 
-/** Mark a field as unusable over the wire - HTTP / capability edges
- * reject it if present; in-process callers may still pass it. */
+/** Client may not set this field. Wire / capability edges reject it if
+ * present; in-process callers may still pass it. */
+export const readonly = <S>(schema: S): S =>
+	withAttrs(schema, "http", { readonly: true });
+
+/**
+ * Exclude this field from responses. When an fn's `output` schema (often
+ * a var) carries it, output validation drops the key.
+ */
+export const returned = <S>(schema: S): S =>
+	withAttrs(schema, "http", { returned: true });
+
+/** @deprecated Prefer {@link readonly}. Same wire gate. */
 export const serverOnly = <S>(schema: S): S =>
 	withAttrs(schema, "http", { serverOnly: true });
 
-const isServerOnly = (schema: unknown) =>
-	attrsOf(schema, "http")?.serverOnly === true;
+const httpAttrs = (schema: unknown) => attrsOf(schema, "http");
 
-/**
- * Drop fields (and nested object keys) marked {@link serverOnly}. Used
- * for OpenAPI / client contracts; {@link InferArgs} on the original
- * schema stays the full shape.
- */
-export const clientSchema = <S>(schema: S): S => {
-	if (isVar(schema)) {
-		const v = schema as { schema?: unknown };
-		return {
-			...(schema as object),
-			schema: v.schema === undefined ? undefined : clientSchema(v.schema as S),
-		} as S;
-	}
-	const def = asType(schema);
-	if (def.name === "object" && def.shape !== undefined) {
-		const shape: Record<string, unknown> = {};
-		for (const [key, child] of Object.entries(
-			def.shape as Record<string, unknown>,
-		)) {
-			if (isServerOnly(child)) continue;
-			shape[key] = clientSchema(child);
-		}
-		return { ...def, shape } as S;
-	}
-	if (def.name === "array" && def.shape !== undefined) {
-		return { ...def, shape: clientSchema(def.shape) } as S;
-	}
-	if (def.name === "union" && Array.isArray(def.shape)) {
-		return {
-			...def,
-			shape: (def.shape as unknown[]).map((option) => clientSchema(option)),
-		} as S;
-	}
-	return schema;
+const isReadonly = (schema: unknown) => {
+	const http = httpAttrs(schema);
+	return http?.readonly === true || http?.serverOnly === true;
 };
 
+const isReturned = (schema: unknown) => httpAttrs(schema)?.returned === true;
+
 /**
- * Throw if any {@link serverOnly} field is present on `value` (own key).
- * Object validation otherwise strips unknown keys, so this is what stops
- * wire callers from smuggling server-only values.
+ * Drop fields marked {@link readonly} / {@link serverOnly}. Used for
+ * OpenAPI / client input contracts; {@link InferArgs} on the original
+ * schema stays the full shape.
  */
-export const rejectServerOnly = (
+export const clientSchema = <S>(schema: S): S => omitFields(schema, isReadonly);
+
+/**
+ * Drop fields marked {@link returned}. Pair with {@link clientSchema} when
+ * projecting an output / response contract.
+ */
+export const responseSchema = <S>(schema: S): S =>
+	omitFields(schema, isReturned);
+
+/**
+ * Throw if any {@link readonly} / {@link serverOnly} field is present on
+ * `value` (own key).
+ */
+export const rejectReadonly = (
 	schema: unknown,
 	value: unknown,
 	path = "input",
-): void => {
-	if (value === null || value === undefined) return;
-	const root = isVar(schema)
-		? ((schema as { schema?: unknown }).schema ?? {})
-		: schema;
-	const def = asType(root);
-	if (def.name === "object" && def.shape !== undefined) {
-		if (typeOf(value) !== "object") return;
-		const record = value as Record<string, unknown>;
-		for (const [key, child] of Object.entries(
-			def.shape as Record<string, unknown>,
-		)) {
-			if (isServerOnly(child) && Object.hasOwn(record, key)) {
-				throw new ValidationError(
-					`${path}.${key}`,
-					"server-only field is not allowed over the wire",
-				);
-			}
-			if (Object.hasOwn(record, key)) {
-				rejectServerOnly(child, record[key], `${path}.${key}`);
-			}
-		}
-		return;
-	}
-	if (def.name === "array" && def.shape !== undefined && Array.isArray(value)) {
-		for (let i = 0; i < value.length; i++) {
-			rejectServerOnly(def.shape, value[i], `${path}[${i}]`);
-		}
-		return;
-	}
-	if (def.name === "union" && Array.isArray(def.shape)) {
-		for (const option of def.shape as unknown[]) {
-			rejectServerOnly(option, value, path);
-		}
-	}
-};
+): void =>
+	rejectFields(
+		schema,
+		value,
+		isReadonly,
+		path,
+		"readonly field is not allowed over the wire",
+	);
+
+/** @deprecated Prefer {@link rejectReadonly}. */
+export const rejectServerOnly = rejectReadonly;
 
 /**
- * Wire-side input gate: reject smuggled server-only keys, then validate
- * against {@link clientSchema}.
+ * Wire-side input gate: reject smuggled readonly keys, then validate
+ * against {@link clientSchema}. Built on core {@link parseFields}.
  */
 export const wireInput = <S>(
 	schema: S,
 	value: unknown,
 	path = "input",
-): unknown => {
-	rejectServerOnly(schema, value, path);
-	return validate(asType(clientSchema(schema)), value, path);
-};
+): unknown =>
+	parseFields(schema, value, {
+		path,
+		reject: isReadonly,
+		omit: isReadonly,
+		rejectMessage: "readonly field is not allowed over the wire",
+	});
 
 /** Parse a JSON request body and run it through {@link wireInput}. */
 export const fromJsonBody = async <S>(
@@ -130,3 +101,9 @@ export const fromJsonBody = async <S>(
 	}
 	return await wireInput(schema, body, path);
 };
+
+/** True when a field carries {@link returned}. Used by `v.fn` output exit. */
+export const isReturnedField = isReturned;
+
+/** Project output schemas the same way `v.fn` does on exit. */
+export const stripReturned = <S>(schema: S): S => responseSchema(schema);

--- a/packages/experimental/src/plugins/http/attrs.ts
+++ b/packages/experimental/src/plugins/http/attrs.ts
@@ -54,7 +54,7 @@ export const rejectReadonly = (
 	schema: unknown,
 	value: unknown,
 	path = "input",
-): void =>
+): void | Promise<void> =>
 	rejectFields(
 		schema,
 		value,
@@ -68,7 +68,7 @@ export const rejectServerOnly = (
 	schema: unknown,
 	value: unknown,
 	path = "input",
-): void => rejectReadonly(schema, value, path);
+): void | Promise<void> => rejectReadonly(schema, value, path);
 
 /**
  * Wire-side input gate: reject smuggled readonly keys, then validate

--- a/packages/experimental/src/plugins/http/attrs.ts
+++ b/packages/experimental/src/plugins/http/attrs.ts
@@ -64,7 +64,11 @@ export const rejectReadonly = (
 	);
 
 /** @deprecated Prefer {@link rejectReadonly}. */
-export const rejectServerOnly = rejectReadonly;
+export const rejectServerOnly = (
+	schema: unknown,
+	value: unknown,
+	path = "input",
+): void => rejectReadonly(schema, value, path);
 
 /**
  * Wire-side input gate: reject smuggled readonly keys, then validate

--- a/packages/experimental/src/plugins/http/index.ts
+++ b/packages/experimental/src/plugins/http/index.ts
@@ -1,8 +1,13 @@
 import {
 	clientSchema,
 	fromJsonBody,
+	readonly,
+	rejectReadonly,
 	rejectServerOnly,
+	responseSchema,
+	returned,
 	serverOnly,
+	stripReturned,
 	wireInput,
 } from "./attrs";
 import { cookieOptions, deleteCookie, getCookie, setCookie } from "./cookie";
@@ -15,8 +20,13 @@ import { res, toResponse } from "./response";
 export {
 	clientSchema,
 	fromJsonBody,
+	readonly,
+	rejectReadonly,
 	rejectServerOnly,
+	responseSchema,
+	returned,
 	serverOnly,
+	stripReturned,
 	wireInput,
 } from "./attrs";
 export type { CookieOptions } from "./cookie";
@@ -70,9 +80,14 @@ export const http = {
 	asResponse,
 	toResponse,
 	Redirect,
+	readonly,
+	returned,
 	serverOnly,
 	clientSchema,
+	responseSchema,
+	rejectReadonly,
 	rejectServerOnly,
+	stripReturned,
 	wireInput,
 	fromJsonBody,
 };

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -558,8 +558,22 @@ export const rejectFields = (
 		return;
 	}
 	if (def.name === "union" && Array.isArray(def.shape)) {
+		// Only gate against arms the value can satisfy once matched
+		// fields are projected out. Checking every arm would reject a
+		// key that is gated on a non-matching arm but free on the one
+		// that actually fits.
 		for (const option of def.shape as unknown[]) {
+			try {
+				const result = validate(asType(omitFields(option, match)), value, path);
+				// Async defaults still count as a candidate; rejection
+				// below stays sync against the arm's shape.
+				void result;
+			} catch (thrown) {
+				if (!(thrown instanceof ValidationError)) throw thrown;
+				continue;
+			}
 			rejectFields(option, value, match, path, message);
+			return;
 		}
 	}
 };

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -523,6 +523,10 @@ export const omitFields = <S>(schema: S, drop: FieldPred): S => {
  * Throw if any field matching `match` is present on `value` (own key).
  * Object validation otherwise strips unknown keys, so this is what stops
  * callers from smuggling gated values.
+ *
+ * May return a Promise when union-arm selection hits an async validate
+ * (async defaults). Callers that already await parse/validate stay sync
+ * for the common case.
  */
 export const rejectFields = (
 	schema: unknown,
@@ -530,7 +534,7 @@ export const rejectFields = (
 	match: FieldPred,
 	path = "input",
 	message = "field is not allowed",
-): void => {
+): void | Promise<void> => {
 	if (value === null || value === undefined) return;
 	const root = isVar(schema)
 		? ((schema as { schema?: unknown }).schema ?? {})
@@ -539,6 +543,7 @@ export const rejectFields = (
 	if (def.name === "object" && def.shape !== undefined) {
 		if (typeOf(value) !== "object") return;
 		const record = value as Record<string, unknown>;
+		let pending: Promise<void> | undefined;
 		for (const [key, child] of Object.entries(
 			def.shape as Record<string, unknown>,
 		)) {
@@ -546,43 +551,62 @@ export const rejectFields = (
 				throw new ValidationError(`${path}.${key}`, message);
 			}
 			if (Object.hasOwn(record, key)) {
-				rejectFields(child, record[key], match, `${path}.${key}`, message);
+				const nested = rejectFields(
+					child,
+					record[key],
+					match,
+					`${path}.${key}`,
+					message,
+				);
+				if (isThenable(nested)) {
+					pending = pending ? pending.then(() => nested) : nested;
+				}
 			}
 		}
-		return;
+		return pending;
 	}
 	if (def.name === "array" && def.shape !== undefined && Array.isArray(value)) {
+		let pending: Promise<void> | undefined;
 		for (let i = 0; i < value.length; i++) {
-			rejectFields(def.shape, value[i], match, `${path}[${i}]`, message);
+			const nested = rejectFields(
+				def.shape,
+				value[i],
+				match,
+				`${path}[${i}]`,
+				message,
+			);
+			if (isThenable(nested)) {
+				pending = pending ? pending.then(() => nested) : nested;
+			}
 		}
-		return;
+		return pending;
 	}
 	if (def.name === "union" && Array.isArray(def.shape)) {
-		// Only gate against arms the value can satisfy once matched
-		// fields are projected out. Checking every arm would reject a
-		// key that is gated on a non-matching arm but free on the one
-		// that actually fits.
-		for (const option of def.shape as unknown[]) {
+		// Pick the arm the FULL schema accepts (same first-success rule as
+		// validate), then gate against that arm only. Projecting gated
+		// fields out before selection would let a wrong earlier arm win.
+		const arms = def.shape as unknown[];
+		const tryArm = (index: number): void | Promise<void> => {
+			const option = arms[index];
+			if (option === undefined) return;
 			try {
-				const result = validate(asType(omitFields(option, match)), value, path);
-				// Async defaults: don't pick this arm sync. Swallow the
-				// rejection so a later sync arm can still win without an
-				// unhandled promise.
-				if (
-					result !== null &&
-					typeof result === "object" &&
-					typeof (result as { then?: unknown }).then === "function"
-				) {
-					(result as Promise<unknown>).then(undefined, () => {});
-					continue;
+				const result = validate(asType(option), value, path);
+				if (isThenable(result)) {
+					return result.then(
+						() => rejectFields(option, value, match, path, message),
+						(thrown) => {
+							if (!(thrown instanceof ValidationError)) throw thrown;
+							return tryArm(index + 1);
+						},
+					);
 				}
 			} catch (thrown) {
 				if (!(thrown instanceof ValidationError)) throw thrown;
-				continue;
+				return tryArm(index + 1);
 			}
-			rejectFields(option, value, match, path, message);
-			return;
-		}
+			return rejectFields(option, value, match, path, message);
+		};
+		return tryArm(0);
 	}
 };
 
@@ -600,6 +624,10 @@ export type ParseFieldsOptions = {
  * Parse `value` against `schema`, optionally rejecting and/or omitting
  * fields by attribute predicate. Core stays attribute-key agnostic -
  * callers pass the predicates (e.g. `attrsOf(s, "http")?.readonly`).
+ *
+ * Unions are special: arm selection uses the FULL schema (so a gated
+ * field that fails typechecks on an earlier arm does not get projected
+ * away and steal the match), then reject/omit run on that arm only.
  */
 export const parseFields = <S>(
 	schema: S,
@@ -607,18 +635,62 @@ export const parseFields = <S>(
 	options: ParseFieldsOptions = {},
 ): unknown => {
 	const path = options.path ?? "input";
-	if (options.reject) {
-		rejectFields(
-			schema,
-			value,
-			options.reject,
-			path,
-			options.rejectMessage ?? "field is not allowed",
-		);
+	const reject = options.reject;
+	const omit = options.omit;
+	const rejectMessage = options.rejectMessage ?? "field is not allowed";
+
+	const root = isVar(schema)
+		? ((schema as { schema?: unknown }).schema ?? schema)
+		: schema;
+	const def = asType(root);
+
+	if (def.name === "union" && Array.isArray(def.shape) && (reject || omit)) {
+		const arms = def.shape as unknown[];
+		const tryArm = (index: number): unknown => {
+			const option = arms[index];
+			if (option === undefined) {
+				// No arm accepted the full value (e.g. required readonly
+				// fields were omitted). Fall back to the projected union
+				// so defaults on those fields can still run.
+				const projected = omit ? omitFields(schema, omit) : schema;
+				return validate(asType(projected), value, path);
+			}
+			const afterMatch = (): unknown => {
+				const gate = reject
+					? rejectFields(option, value, reject, path, rejectMessage)
+					: undefined;
+				const finish = () => {
+					const projected = omit ? omitFields(option, omit) : option;
+					return validate(asType(projected), value, path);
+				};
+				return isThenable(gate) ? gate.then(finish) : finish();
+			};
+			try {
+				const matched = validate(asType(option), value, path);
+				if (isThenable(matched)) {
+					return matched.then(afterMatch, (thrown) => {
+						if (!(thrown instanceof ValidationError)) throw thrown;
+						return tryArm(index + 1);
+					});
+				}
+			} catch (thrown) {
+				if (!(thrown instanceof ValidationError)) throw thrown;
+				return tryArm(index + 1);
+			}
+			return afterMatch();
+		};
+		return tryArm(0);
 	}
-	const projected = options.omit ? omitFields(schema, options.omit) : schema;
-	return validate(asType(projected), value, path);
+
+	const projected = omit ? omitFields(schema, omit) : schema;
+	const finish = () => validate(asType(projected), value, path);
+	if (!reject) return finish();
+	const gated = rejectFields(schema, value, reject, path, rejectMessage);
+	return isThenable(gated) ? gated.then(finish) : finish();
 };
+
+const isThenable = (value: unknown): value is Promise<unknown> =>
+	typeof (value as { then?: unknown })?.then === "function";
 
 export const typeOf = (value: unknown) =>
 	value === null
@@ -808,9 +880,6 @@ const applyRules = (def: Rules, value: any, path: string) => {
 		}
 	}
 };
-
-const isThenable = (value: unknown): value is Promise<unknown> =>
-	typeof (value as { then?: unknown })?.then === "function";
 
 /** Sync when every entry is sync; Promise when any is thenable. */
 const allMaybeAsync = <T>(values: Array<T | Promise<T>>): T[] | Promise<T[]> =>

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -440,7 +440,8 @@ const withAttrBag = <S>(schema: S, bag: AttrBag): S => {
 /**
  * Attach plugin attributes under `namespace`, deep-merging with any
  * already on the schema. Returns a new type def (or var) with the same
- * value type. Core never reads these - only plugin edges do.
+ * value type. Core mostly ignores these - plugin edges and a few
+ * exit paths (e.g. `v.fn` stripping `http.returned`) consume them.
  *
  * Passed a var, attributes land on the var itself (`$attrs`) and the
  * `$var` / `name` / `schema` identity is preserved; `customize` is rebound
@@ -478,6 +479,124 @@ export function attrsOf(
 	if (!bag) return undefined;
 	return namespace === undefined ? bag : bag[namespace];
 }
+
+/** Decide whether a field schema (type def or var) should be dropped / rejected. */
+export type FieldPred = (schema: unknown) => boolean;
+
+/**
+ * Drop fields (and nested object / array / union children) where `drop`
+ * is true. Vars keep their identity; only the inner `schema` is projected.
+ * Used by plugin edges and by {@link parseFields}.
+ */
+export const omitFields = <S>(schema: S, drop: FieldPred): S => {
+	if (isVar(schema)) {
+		const v = schema as { schema?: unknown };
+		return {
+			...(schema as object),
+			schema: v.schema === undefined ? undefined : omitFields(v.schema, drop),
+		} as S;
+	}
+	const def = asType(schema);
+	if (def.name === "object" && def.shape !== undefined) {
+		const shape: Record<string, unknown> = {};
+		for (const [key, child] of Object.entries(
+			def.shape as Record<string, unknown>,
+		)) {
+			if (drop(child)) continue;
+			shape[key] = omitFields(child, drop);
+		}
+		return { ...def, shape } as S;
+	}
+	if (def.name === "array" && def.shape !== undefined) {
+		return { ...def, shape: omitFields(def.shape, drop) } as S;
+	}
+	if (def.name === "union" && Array.isArray(def.shape)) {
+		return {
+			...def,
+			shape: (def.shape as unknown[]).map((option) => omitFields(option, drop)),
+		} as S;
+	}
+	return schema;
+};
+
+/**
+ * Throw if any field matching `match` is present on `value` (own key).
+ * Object validation otherwise strips unknown keys, so this is what stops
+ * callers from smuggling gated values.
+ */
+export const rejectFields = (
+	schema: unknown,
+	value: unknown,
+	match: FieldPred,
+	path = "input",
+	message = "field is not allowed",
+): void => {
+	if (value === null || value === undefined) return;
+	const root = isVar(schema)
+		? ((schema as { schema?: unknown }).schema ?? {})
+		: schema;
+	const def = asType(root);
+	if (def.name === "object" && def.shape !== undefined) {
+		if (typeOf(value) !== "object") return;
+		const record = value as Record<string, unknown>;
+		for (const [key, child] of Object.entries(
+			def.shape as Record<string, unknown>,
+		)) {
+			if (match(child) && Object.hasOwn(record, key)) {
+				throw new ValidationError(`${path}.${key}`, message);
+			}
+			if (Object.hasOwn(record, key)) {
+				rejectFields(child, record[key], match, `${path}.${key}`, message);
+			}
+		}
+		return;
+	}
+	if (def.name === "array" && def.shape !== undefined && Array.isArray(value)) {
+		for (let i = 0; i < value.length; i++) {
+			rejectFields(def.shape, value[i], match, `${path}[${i}]`, message);
+		}
+		return;
+	}
+	if (def.name === "union" && Array.isArray(def.shape)) {
+		for (const option of def.shape as unknown[]) {
+			rejectFields(option, value, match, path, message);
+		}
+	}
+};
+
+export type ParseFieldsOptions = {
+	path?: string;
+	/** Throw when these fields are present on the value (own key). */
+	reject?: FieldPred;
+	/** Drop these fields from the schema before validating. */
+	omit?: FieldPred;
+	/** Message used when {@link reject} fires. */
+	rejectMessage?: string;
+};
+
+/**
+ * Parse `value` against `schema`, optionally rejecting and/or omitting
+ * fields by attribute predicate. Core stays attribute-key agnostic -
+ * callers pass the predicates (e.g. `attrsOf(s, "http")?.readonly`).
+ */
+export const parseFields = <S>(
+	schema: S,
+	value: unknown,
+	options: ParseFieldsOptions = {},
+): unknown => {
+	const path = options.path ?? "input";
+	if (options.reject) {
+		rejectFields(
+			schema,
+			value,
+			options.reject,
+			path,
+			options.rejectMessage ?? "field is not allowed",
+		);
+	}
+	const projected = options.omit ? omitFields(schema, options.omit) : schema;
+	return validate(asType(projected), value, path);
+};
 
 export const typeOf = (value: unknown) =>
 	value === null

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -520,6 +520,39 @@ export const omitFields = <S>(schema: S, drop: FieldPred): S => {
 };
 
 /**
+ * Strip keys from an already-validated value where `drop` matches the
+ * field schema. Used after union arm selection so defaults/transforms
+ * from the probe validate are not run a second time.
+ */
+const omitValue = (
+	schema: unknown,
+	value: unknown,
+	drop: FieldPred,
+): unknown => {
+	if (value === null || value === undefined) return value;
+	const root = isVar(schema)
+		? ((schema as { schema?: unknown }).schema ?? schema)
+		: schema;
+	const def = asType(root);
+	if (def.name === "object" && def.shape !== undefined) {
+		if (typeOf(value) !== "object") return value;
+		const record = value as Record<string, unknown>;
+		const out: Record<string, unknown> = {};
+		for (const [key, child] of Object.entries(
+			def.shape as Record<string, unknown>,
+		)) {
+			if (drop(child) || !Object.hasOwn(record, key)) continue;
+			out[key] = omitValue(child, record[key], drop);
+		}
+		return out;
+	}
+	if (def.name === "array" && def.shape !== undefined && Array.isArray(value)) {
+		return value.map((item) => omitValue(def.shape, item, drop));
+	}
+	return value;
+};
+
+/**
  * Throw if any field matching `match` is present on `value` (own key).
  * Object validation otherwise strips unknown keys, so this is what stops
  * callers from smuggling gated values.
@@ -684,52 +717,51 @@ export const parseFields = <S>(
 						return validate(asType(projected), value, path);
 					}
 					const projected = omit ? omitFields(arm, omit) : arm;
-					const finish = () => validate(asType(projected), value, path);
-					const afterFit = (): unknown => {
+					const afterFit = (fitted: unknown): unknown => {
 						const gate = reject
 							? rejectFields(arm, value, reject, path, rejectMessage)
 							: undefined;
-						return isThenable(gate) ? gate.then(finish) : finish();
+						return isThenable(gate) ? gate.then(() => fitted) : fitted;
 					};
+					let fitted: unknown;
 					try {
-						const fitted = validate(asType(projected), value, path);
-						if (isThenable(fitted)) {
-							return fitted.then(afterFit, (thrown) => {
-								if (!(thrown instanceof ValidationError)) throw thrown;
-								return tryProjected(i + 1);
-							});
-						}
+						fitted = validate(asType(projected), value, path);
 					} catch (thrown) {
 						if (!(thrown instanceof ValidationError)) throw thrown;
 						return tryProjected(i + 1);
 					}
-					return afterFit();
+					if (isThenable(fitted)) {
+						return fitted.then(afterFit, (thrown) => {
+							if (!(thrown instanceof ValidationError)) throw thrown;
+							return tryProjected(i + 1);
+						});
+					}
+					return afterFit(fitted);
 				};
 				return tryProjected(0);
 			}
-			const afterMatch = (): unknown => {
+			const afterMatch = (matched: unknown): unknown => {
 				const gate = reject
 					? rejectFields(option, value, reject, path, rejectMessage)
 					: undefined;
-				const finish = () => {
-					const projected = omit ? omitFields(option, omit) : option;
-					return validate(asType(projected), value, path);
-				};
+				const finish = () =>
+					omit ? omitValue(option, matched, omit) : matched;
 				return isThenable(gate) ? gate.then(finish) : finish();
 			};
+			let matched: unknown;
 			try {
-				const matched = validate(asType(option), value, path);
-				if (isThenable(matched)) {
-					return matched.then(afterMatch, (thrown) => {
-						if (!(thrown instanceof ValidationError)) throw thrown;
-						return tryArm(index + 1);
-					});
-				}
+				matched = validate(asType(option), value, path);
 			} catch (thrown) {
 				if (!(thrown instanceof ValidationError)) throw thrown;
 				return tryArm(index + 1);
 			}
-			return afterMatch();
+			if (isThenable(matched)) {
+				return matched.then(afterMatch, (thrown) => {
+					if (!(thrown instanceof ValidationError)) throw thrown;
+					return tryArm(index + 1);
+				});
+			}
+			return afterMatch(matched);
 		};
 		return tryArm(0);
 	}

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -588,7 +588,32 @@ export const rejectFields = (
 		const arms = def.shape as unknown[];
 		const tryArm = (index: number): void | Promise<void> => {
 			const option = arms[index];
-			if (option === undefined) return;
+			if (option === undefined) {
+				// Nested unions hit this path from object walks. Still gate
+				// against a projected fit so a wrong-typed readonly key
+				// cannot be stripped by a later omit pass.
+				const tryProjected = (i: number): void | Promise<void> => {
+					const arm = arms[i];
+					if (arm === undefined) return;
+					const projected = omitFields(arm, match);
+					const afterFit = (): void | Promise<void> =>
+						rejectFields(arm, value, match, path, message);
+					try {
+						const fitted = validate(asType(projected), value, path);
+						if (isThenable(fitted)) {
+							return fitted.then(afterFit, (thrown) => {
+								if (!(thrown instanceof ValidationError)) throw thrown;
+								return tryProjected(i + 1);
+							});
+						}
+					} catch (thrown) {
+						if (!(thrown instanceof ValidationError)) throw thrown;
+						return tryProjected(i + 1);
+					}
+					return afterFit();
+				};
+				return tryProjected(0);
+			}
 			try {
 				const result = validate(asType(option), value, path);
 				if (isThenable(result)) {

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -565,9 +565,17 @@ export const rejectFields = (
 		for (const option of def.shape as unknown[]) {
 			try {
 				const result = validate(asType(omitFields(option, match)), value, path);
-				// Async defaults still count as a candidate; rejection
-				// below stays sync against the arm's shape.
-				void result;
+				// Async defaults: don't pick this arm sync. Swallow the
+				// rejection so a later sync arm can still win without an
+				// unhandled promise.
+				if (
+					result !== null &&
+					typeof result === "object" &&
+					typeof (result as { then?: unknown }).then === "function"
+				) {
+					(result as Promise<unknown>).then(undefined, () => {});
+					continue;
+				}
 			} catch (thrown) {
 				if (!(thrown instanceof ValidationError)) throw thrown;
 				continue;

--- a/packages/experimental/src/schema.ts
+++ b/packages/experimental/src/schema.ts
@@ -649,11 +649,38 @@ export const parseFields = <S>(
 		const tryArm = (index: number): unknown => {
 			const option = arms[index];
 			if (option === undefined) {
-				// No arm accepted the full value (e.g. required readonly
-				// fields were omitted). Fall back to the projected union
-				// so defaults on those fields can still run.
-				const projected = omit ? omitFields(schema, omit) : schema;
-				return validate(asType(projected), value, path);
+				// No arm accepted the full value. Still pick a projected
+				// arm and gate against it: a wrong-typed readonly key
+				// fails the full arm but must not be silently stripped.
+				const tryProjected = (i: number): unknown => {
+					const arm = arms[i];
+					if (arm === undefined) {
+						const projected = omit ? omitFields(schema, omit) : schema;
+						return validate(asType(projected), value, path);
+					}
+					const projected = omit ? omitFields(arm, omit) : arm;
+					const finish = () => validate(asType(projected), value, path);
+					const afterFit = (): unknown => {
+						const gate = reject
+							? rejectFields(arm, value, reject, path, rejectMessage)
+							: undefined;
+						return isThenable(gate) ? gate.then(finish) : finish();
+					};
+					try {
+						const fitted = validate(asType(projected), value, path);
+						if (isThenable(fitted)) {
+							return fitted.then(afterFit, (thrown) => {
+								if (!(thrown instanceof ValidationError)) throw thrown;
+								return tryProjected(i + 1);
+							});
+						}
+					} catch (thrown) {
+						if (!(thrown instanceof ValidationError)) throw thrown;
+						return tryProjected(i + 1);
+					}
+					return afterFit();
+				};
+				return tryProjected(0);
 			}
 			const afterMatch = (): unknown => {
 				const gate = reject


### PR DESCRIPTION
Wire and capability edges can reject fields the client must not set, and `v.fn` output validation strips fields that must not leave in the response. I also lifted the schema walk into core (`parseFields` / `omitFields` / `rejectFields`) so those gates stay attribute-key agnostic.

`http.serverOnly` still works as a deprecated alias of the readonly gate.