### PR TITLE
feat(experimental): add modular event categories with extend and v.on

### DIFF
--- a/packages/experimental/src/event.test.ts
+++ b/packages/experimental/src/event.test.ts
@@ -71,6 +71,36 @@ describe("v.event", () => {
 		expect(result).toEqual({ v: 1 });
 		expect(order).toEqual(["outer", "veto"]);
 	});
+
+	it("keeps the chain when next is called without awaiting", async () => {
+		const bus = v.event("evt_detach", {
+			x: v.object({ v: v.number() }),
+		});
+		const order: string[] = [];
+		bus.subscribe((_e, next) => {
+			order.push("outer");
+			// Fire-and-forget: publish must still wait for downstream.
+			void next();
+		});
+		bus.subscribe(async (_e, next) => {
+			await new Promise((r) => setTimeout(r, 5));
+			order.push("inner");
+			await next({ v: 2 });
+		});
+		const result = await bus.publish("x", { v: 1 });
+		expect(result).toEqual({ v: 2 });
+		expect(order).toEqual(["outer", "inner"]);
+	});
+
+	it("re-validates next() patches against the kind schema", async () => {
+		const bus = v.event("evt_patch_validate", {
+			x: v.object({ v: v.number() }),
+		});
+		bus.subscribe(async (_e, next) => {
+			await next({ v: "nope" } as never);
+		});
+		await expect(bus.publish("x", { v: 1 })).rejects.toThrow(/expected number/);
+	});
 });
 
 describe("event extension + modules", () => {

--- a/packages/experimental/src/event.test.ts
+++ b/packages/experimental/src/event.test.ts
@@ -101,6 +101,28 @@ describe("v.event", () => {
 		});
 		await expect(bus.publish("x", { v: 1 })).rejects.toThrow(/expected number/);
 	});
+
+	it("does not re-transform untouched fields on next() patches", async () => {
+		let transforms = 0;
+		const bus = v.event("evt_patch_transform", {
+			x: v.object({
+				a: v.string({
+					transform: (value) => {
+						transforms += 1;
+						return `${value}!`;
+					},
+				}),
+				b: v.number(),
+			}),
+		});
+		bus.subscribe(async (e, next) => {
+			expect(e.data.a).toBe("hi!");
+			await next({ b: 2 });
+		});
+		const result = await bus.publish("x", { a: "hi", b: 1 });
+		expect(result).toEqual({ a: "hi!", b: 2 });
+		expect(transforms).toBe(1);
+	});
 });
 
 describe("event extension + modules", () => {

--- a/packages/experimental/src/event.test.ts
+++ b/packages/experimental/src/event.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { type ModuleEvents, v } from "./index";
+
+describe("v.event", () => {
+	it("publishes through direct subscribers and merges next() patches", async () => {
+		const signUp = v.event("evt_signup", {
+			email: v.object({
+				id: v.string(),
+				name: v.string(),
+				email: v.string(),
+			}),
+			emailOpt: v.object({ id: v.string(), email: v.string() }),
+		});
+
+		const seen: string[] = [];
+		const unsubscribe = signUp.subscribe(async (e, next) => {
+			seen.push(String(e.type));
+			if (e.type === "emailOpt") {
+				await next({ email: "patched@example.com" });
+				return;
+			}
+			await next();
+		});
+
+		const result = await signUp.publish("emailOpt", {
+			id: "1",
+			email: "ada@example.com",
+		});
+		expect(result).toEqual({ id: "1", email: "patched@example.com" });
+		expect(seen).toEqual(["emailOpt"]);
+
+		unsubscribe();
+		await signUp.publish("email", {
+			id: "2",
+			name: "Ada",
+			email: "ada@example.com",
+		});
+		expect(seen).toEqual(["emailOpt"]);
+	});
+
+	it("validates payloads and rejects unknown kinds", async () => {
+		const bus = v.event("evt_validate", {
+			ping: v.object({ n: v.number() }),
+		});
+		expect(() => bus.publish("ping", { n: "x" } as never)).toThrow(
+			/expected number/,
+		);
+		expect(() => (bus as any).publish("pong", { n: 1 })).toThrow(
+			/unknown event kind/,
+		);
+		expect(bus.publish("ping", { n: 1 })).toEqual({ n: 1 });
+	});
+
+	it("skips the chain when next is not called (veto)", async () => {
+		const bus = v.event("evt_veto", {
+			x: v.object({ v: v.number() }),
+		});
+		const order: string[] = [];
+		bus.subscribe(async (_e, next) => {
+			order.push("outer");
+			await next();
+		});
+		bus.subscribe(async () => {
+			order.push("veto");
+		});
+		bus.subscribe(async (_e, next) => {
+			order.push("inner");
+			await next();
+		});
+		const result = await bus.publish("x", { v: 1 });
+		expect(result).toEqual({ v: 1 });
+		expect(order).toEqual(["outer", "veto"]);
+	});
+});
+
+describe("event extension + modules", () => {
+	it("v.extend / .extend widen kinds; modules mount listeners", async () => {
+		const signUp = v.event("evt_mod_signup", {
+			email: v.object({ id: v.string(), email: v.string() }),
+		});
+		const withOauth = signUp.extend({
+			oauth: v.object({ provider: v.string(), id: v.string() }),
+		});
+		const oauthExt = v.extend(signUp, {
+			oauth: v.object({ provider: v.string(), id: v.string() }),
+		});
+
+		expectTypeOf<keyof typeof withOauth.types>().toEqualTypeOf<
+			"email" | "oauth"
+		>();
+
+		const log: string[] = [];
+		const onSignUp = v.on(signUp, async (e, next) => {
+			log.push(`on:${String(e.type)}`);
+			await next();
+		});
+		const onKey = v.on("event.evt_mod_signup", async (e, next) => {
+			log.push(`key:${String(e.type)}`);
+			await next();
+		});
+
+		const core = { signUp, oauthExt };
+		const hooks = { onSignUp, onKey };
+
+		// Mounting a fn that uses the module registers event listeners.
+		v.fn("evt_mod.app", { use: [core, hooks] }, () => "ok");
+
+		const fromEmail = await signUp.publish("email", {
+			id: "1",
+			email: "a@b.co",
+		});
+		expect(fromEmail).toEqual({ id: "1", email: "a@b.co" });
+
+		const fromOauth = await withOauth.publish("oauth", {
+			provider: "github",
+			id: "42",
+		});
+		expect(fromOauth).toEqual({ provider: "github", id: "42" });
+		expect(log).toEqual(["on:email", "key:email", "on:oauth", "key:oauth"]);
+	});
+
+	it("ModuleEvents merges kind maps by declared name across modules", () => {
+		const a = {
+			signUp: v.event("evt_infer", {
+				email: v.object({ id: v.string() }),
+			}),
+		};
+		const b = {
+			more: v.extend(a.signUp, {
+				oauth: v.object({ provider: v.string() }),
+			}),
+		};
+		type Merged = ModuleEvents<[typeof a, typeof b]>;
+		type KindMap = Merged extends { evt_infer: infer K } ? K : never;
+		// Structural assignability both ways = equal payload maps.
+		const _forward = null as unknown as KindMap;
+		const _expected = null as unknown as {
+			email: { id: string };
+			oauth: { provider: string };
+		};
+		const _a: typeof _expected = _forward;
+		const _b: KindMap = _expected;
+		void _a;
+		void _b;
+	});
+
+	it("lands on context when mounted via use", async () => {
+		const bus = v.event("evt_ctx", {
+			ping: v.object({ n: v.number() }),
+		});
+		const seen: number[] = [];
+		bus.subscribe(async (e, next) => {
+			if (e.type === "ping") seen.push(e.data.n);
+			await next();
+		});
+		const f = v.fn({ use: [{ bus }] }, async (c) => {
+			return c.bus.publish("ping", { n: 7 });
+		});
+		await expect(f()).resolves.toEqual({ n: 7 });
+		expect(seen).toEqual([7]);
+	});
+});

--- a/packages/experimental/src/event.ts
+++ b/packages/experimental/src/event.ts
@@ -1,0 +1,314 @@
+import { asType, type InferInput, validate } from "./schema";
+import type {
+	LiteralString,
+	Members,
+	Prettify,
+	UnionToIntersection,
+} from "./types";
+
+/** Payload for each kind in an event-type map. */
+export type EventPayloads<T> = {
+	[K in keyof T]: InferInput<T[K]>;
+};
+
+/** Discriminated message handed to subscribers. */
+export type EventMessage<T> = Prettify<
+	{
+		[K in keyof T]: { type: K; data: EventPayloads<T>[K] };
+	}[keyof T]
+>;
+
+/** `next(mutate?)` continues the chain and optionally patches this publish's
+ * payload. Skipping `next` stops the chain (veto), same idea as `v.on`. */
+export type EventNext<D> = (mutate?: Partial<D>) => void | Promise<void>;
+
+export type EventHandler<T> = (
+	event: EventMessage<T>,
+	next: EventNext<EventPayloads<T>[keyof T]>,
+) => void | Promise<void>;
+
+/**
+ * A named event CATEGORY: several kinds under one namespace, each with a
+ * payload schema. Distinct from a fn lifecycle (`v.on(fn)` listens to one
+ * key) - subscribers here hear every kind the category declares, and modules
+ * can widen the kind map by name the same way `v.extend` widens vars.
+ */
+export interface EventDefination<
+	N extends LiteralString,
+	T extends Record<string, unknown> = Record<string, never>,
+> {
+	$event: true;
+	name: N;
+	types: T;
+	/**
+	 * Register a listener on this bus. Returns unsubscribe. Always-on -
+	 * does not need a module mount.
+	 */
+	subscribe: (handler: EventHandler<T>) => () => void;
+	/**
+	 * Validate `data` against the kind's schema, run subscribers (direct +
+	 * any mounted via `v.on` / modules), merge `next` mutations, return the
+	 * final payload.
+	 */
+	publish: <K extends keyof T & string>(
+		type: K,
+		data: EventPayloads<T>[K],
+	) => EventPayloads<T>[K] | Promise<EventPayloads<T>[K]>;
+	/**
+	 * Mint a NEW event def under the same name with more kinds - the
+	 * re-export pattern (`customize` for vars). Shared bus; widened types.
+	 */
+	extend: <E extends Record<string, unknown>>(
+		types: E,
+	) => EventDefination<N, Prettify<T & E>>;
+}
+
+/**
+ * Mountable kind-map widening. Where {@link EventDefination.extend} mints a
+ * re-export, an extension is a module member: every scope that `use`s it
+ * sees the named event widened, and nothing that doesn't is affected.
+ * Handed the event by REFERENCE, mounting just the extension also brings
+ * the base event (same rule as `v.extend` on vars).
+ */
+export type EventExtension<
+	N extends string,
+	T extends Record<string, unknown>,
+	BaseT extends Record<string, unknown> = Record<string, never>,
+> = {
+	$eventExtend: true;
+	name: N;
+	types: T;
+	base?: EventDefination<N & LiteralString, BaseT>;
+};
+
+/**
+ * A mountable listener on an event category. Distinct from fn/`var.*`
+ * {@link OnEntry}: the handler sees `{ type, data }`, not a fn context.
+ * Collected when a module that exports it is `use`d (identity-deduped).
+ */
+export type EventOnEntry<
+	N extends string,
+	T extends Record<string, unknown> = Record<string, unknown>,
+> = {
+	$eventOn: true;
+	name: N;
+	handler: EventHandler<T>;
+};
+
+export const isEvent = (
+	value: unknown,
+): value is EventDefination<LiteralString, Record<string, unknown>> =>
+	typeof value === "object" &&
+	value !== null &&
+	(value as { $event?: unknown }).$event === true;
+
+export const isEventExtension = (
+	value: unknown,
+): value is EventExtension<string, Record<string, unknown>> =>
+	typeof value === "object" &&
+	value !== null &&
+	(value as { $eventExtend?: unknown }).$eventExtend === true;
+
+export const isEventOn = (value: unknown): value is EventOnEntry<string> =>
+	typeof value === "object" &&
+	value !== null &&
+	(value as { $eventOn?: unknown }).$eventOn === true;
+
+type Bus = {
+	types: Record<string, unknown>;
+	/** Direct `.subscribe` listeners. */
+	direct: Set<EventHandler<any>>;
+	/** Module-mounted `v.on(event, …)` listeners - keyed by entry identity. */
+	mounted: Set<EventHandler<any>>;
+};
+
+const eventRegistry = new Map<string, Bus>();
+
+const getBus = (name: string): Bus => {
+	let bus = eventRegistry.get(name);
+	if (!bus) {
+		bus = { types: {}, direct: new Set(), mounted: new Set() };
+		eventRegistry.set(name, bus);
+	}
+	return bus;
+};
+
+const mergeTypes = (bus: Bus, types: Record<string, unknown> | undefined) => {
+	if (!types) return;
+	bus.types = { ...bus.types, ...types };
+};
+
+const isThenable = (value: unknown): value is Promise<unknown> =>
+	typeof (value as { then?: unknown })?.then === "function";
+
+const thenMaybe = <T, R>(
+	value: T | Promise<T>,
+	next: (value: T) => R | Promise<R>,
+): R | Promise<R> => (isThenable(value) ? value.then(next) : next(value as T));
+
+/**
+ * Run handlers outermost-first (mount / subscribe order). Each may call
+ * `next(mutate?)` to continue and patch the payload; skipping `next` vetoes.
+ */
+const runHandlers = (
+	handlers: readonly EventHandler<any>[],
+	type: string,
+	initial: unknown,
+): unknown | Promise<unknown> => {
+	let current = initial;
+	const run = (i: number): void | Promise<void> => {
+		if (i >= handlers.length) return;
+		let proceeded = false;
+		const next = (mutate?: Partial<unknown>) => {
+			proceeded = true;
+			if (
+				mutate !== undefined &&
+				mutate !== null &&
+				typeof mutate === "object"
+			) {
+				current = {
+					...(current as Record<string, unknown>),
+					...(mutate as Record<string, unknown>),
+				};
+			}
+			return run(i + 1);
+		};
+		const handler = handlers[i];
+		if (!handler) return;
+		const result = handler({ type, data: current }, next);
+		return thenMaybe(result, () => {
+			if (!proceeded) return;
+		});
+	};
+	return thenMaybe(run(0), () => current);
+};
+
+const publishOn = (
+	name: string,
+	type: string,
+	data: unknown,
+): unknown | Promise<unknown> => {
+	const bus = getBus(name);
+	const schema = bus.types[type];
+	const path = `event.${name}.${type}`;
+	if (schema === undefined) {
+		throw new Error(`${path}: unknown event kind "${type}"`);
+	}
+	const handlers = [...bus.mounted, ...bus.direct];
+	return thenMaybe(validate(asType(schema), data, path), (parsed) =>
+		runHandlers(handlers, type, parsed),
+	);
+};
+
+/** Register a module-mounted event listener (no-op if already present). */
+export const mountEventOn = (entry: EventOnEntry<string>) => {
+	getBus(entry.name).mounted.add(entry.handler);
+};
+
+/** Merge extension kinds onto the named bus (and ensure a bus exists). */
+export const mountEventExtension = (
+	ext: EventExtension<string, Record<string, unknown>>,
+) => {
+	const bus = getBus(ext.name);
+	if (ext.base) mergeTypes(bus, ext.base.types as Record<string, unknown>);
+	mergeTypes(bus, ext.types);
+};
+
+/** Ensure a declared event is on the bus (kinds merged by name). */
+export const mountEvent = (
+	event: EventDefination<LiteralString, Record<string, unknown>>,
+) => {
+	mergeTypes(getBus(event.name), event.types as Record<string, unknown>);
+};
+
+export const makeEvent = <
+	N extends LiteralString,
+	const T extends Record<string, unknown> = Record<string, never>,
+>(
+	name: N,
+	types?: T,
+): EventDefination<N, T> => {
+	const bus = getBus(name);
+	if (types) mergeTypes(bus, types as Record<string, unknown>);
+
+	const def: EventDefination<N, T> = {
+		$event: true,
+		name,
+		types: (types ?? {}) as T,
+		subscribe: (handler) => {
+			bus.direct.add(handler as EventHandler<any>);
+			return () => {
+				bus.direct.delete(handler as EventHandler<any>);
+			};
+		},
+		publish: (type, data) => publishOn(name, type, data) as never,
+		extend: (extra) =>
+			makeEvent(name, {
+				...(types ?? {}),
+				...extra,
+			}) as never,
+	};
+	return def;
+};
+
+export function extendEvent<
+	N extends LiteralString,
+	T extends Record<string, unknown>,
+	const E extends Record<string, unknown>,
+>(target: EventDefination<N, T>, types: E): EventExtension<N, E, T>;
+export function extendEvent<
+	N extends LiteralString,
+	const E extends Record<string, unknown>,
+>(target: N, types: E): EventExtension<N, E>;
+export function extendEvent(
+	target: EventDefination<string, Record<string, unknown>> | string,
+	types: Record<string, unknown>,
+): EventExtension<string, Record<string, unknown>, any> {
+	return typeof target === "string"
+		? { $eventExtend: true, name: target, types }
+		: {
+				$eventExtend: true,
+				name: target.name,
+				types,
+				base: target as EventDefination<any, any>,
+			};
+}
+
+/** Build a mountable event listener from an event ref or `event.<name>` key. */
+export function onEvent<
+	N extends LiteralString,
+	T extends Record<string, unknown>,
+>(target: EventDefination<N, T>, handler: EventHandler<T>): EventOnEntry<N, T>;
+export function onEvent<N extends LiteralString>(
+	target: `event.${N}`,
+	handler: EventHandler<Record<string, unknown>>,
+): EventOnEntry<N>;
+export function onEvent(target: any, handler: any): EventOnEntry<string, any> {
+	const name =
+		typeof target === "string" ? target.slice("event.".length) : target.name;
+	return { $eventOn: true, name, handler };
+}
+
+/* ----------------------------- module types ------------------------------ */
+
+type EventTypesEntry<M> = {
+	[K in keyof M]: M[K] extends EventDefination<infer N, infer T>
+		? { [P in N]: EventPayloads<T> }
+		: M[K] extends EventExtension<infer N, infer T, any>
+			? { [P in N]: EventPayloads<T> }
+			: never;
+}[keyof M];
+
+/**
+ * Event payload maps a module exports, keyed by DECLARED event name. Same
+ * name across modules intersects (kinds merge) - the var-extension rule.
+ * Prefer {@link ModuleEvents} over a bare union of modules.
+ */
+export type EventsFrom<M> = M extends unknown
+	? [EventTypesEntry<M>] extends [never]
+		? never
+		: UnionToIntersection<EventTypesEntry<M>>
+	: never;
+
+/** Events contributed by a `use` list - intersects same-name kind maps. */
+export type ModuleEvents<PL> = UnionToIntersection<EventsFrom<Members<PL>>>;

--- a/packages/experimental/src/event.ts
+++ b/packages/experimental/src/event.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from "./error";
 import { asType, type InferInput, validate } from "./schema";
 import type {
 	LiteralString,
@@ -147,10 +148,52 @@ const thenMaybe = <T, R>(
 ): R | Promise<R> => (isThenable(value) ? value.then(next) : next(value as T));
 
 /**
+ * Validate only the keys in `patch` against an object shape, then merge onto
+ * `current`. Avoids re-running transforms on unchanged fields (full-object
+ * re-validate would). Non-object schemas fall back to validating the merge.
+ */
+const applyPatch = (
+	schema: unknown,
+	current: unknown,
+	patch: Record<string, unknown>,
+	path: string,
+): unknown | Promise<unknown> => {
+	const def = asType(schema);
+	const shape = def.shape as Record<string, unknown> | undefined;
+	if (def.name !== "object" || shape === undefined) {
+		return validate(
+			def,
+			{ ...(current as Record<string, unknown>), ...patch },
+			path,
+		);
+	}
+	const keys = Object.keys(patch);
+	for (const key of keys) {
+		if (!(key in shape)) {
+			throw new ValidationError(`${path}.${key}`, `unexpected key "${key}"`);
+		}
+	}
+	const walk = (
+		index: number,
+		acc: Record<string, unknown>,
+	): Record<string, unknown> | Promise<Record<string, unknown>> => {
+		if (index >= keys.length) {
+			return { ...(current as Record<string, unknown>), ...acc };
+		}
+		const key = keys[index] as string;
+		return thenMaybe(
+			validate(asType(shape[key]), patch[key], `${path}.${key}`),
+			(parsed) => walk(index + 1, { ...acc, [key]: parsed }),
+		);
+	};
+	return walk(0, {});
+};
+
+/**
  * Run handlers outermost-first (mount / subscribe order). Each may call
  * `next(mutate?)` to continue and patch the payload; skipping `next` vetoes.
- * Patches re-validate against the kind schema. Calling `next` without
- * awaiting it still keeps the downstream chain attached to `publish`.
+ * Patches validate only the touched fields. Calling `next` without awaiting
+ * it still keeps the downstream chain attached to `publish`.
  */
 const runHandlers = (
 	handlers: readonly EventHandler<any>[],
@@ -175,12 +218,8 @@ const runHandlers = (
 				mutate !== null &&
 				typeof mutate === "object"
 			) {
-				const merged = {
-					...(current as Record<string, unknown>),
-					...(mutate as Record<string, unknown>),
-				};
 				downstream = thenMaybe(
-					validate(asType(schema), merged, path),
+					applyPatch(schema, current, mutate as Record<string, unknown>, path),
 					continueChain,
 				);
 			} else {

--- a/packages/experimental/src/event.ts
+++ b/packages/experimental/src/event.ts
@@ -149,35 +149,51 @@ const thenMaybe = <T, R>(
 /**
  * Run handlers outermost-first (mount / subscribe order). Each may call
  * `next(mutate?)` to continue and patch the payload; skipping `next` vetoes.
+ * Patches re-validate against the kind schema. Calling `next` without
+ * awaiting it still keeps the downstream chain attached to `publish`.
  */
 const runHandlers = (
 	handlers: readonly EventHandler<any>[],
 	type: string,
 	initial: unknown,
+	schema: unknown,
+	path: string,
 ): unknown | Promise<unknown> => {
 	let current = initial;
 	const run = (i: number): void | Promise<void> => {
 		if (i >= handlers.length) return;
-		let proceeded = false;
+		let called = false;
+		let downstream: void | Promise<void>;
 		const next = (mutate?: Partial<unknown>) => {
-			proceeded = true;
+			called = true;
+			const continueChain = (value: unknown) => {
+				current = value;
+				return run(i + 1);
+			};
 			if (
 				mutate !== undefined &&
 				mutate !== null &&
 				typeof mutate === "object"
 			) {
-				current = {
+				const merged = {
 					...(current as Record<string, unknown>),
 					...(mutate as Record<string, unknown>),
 				};
+				downstream = thenMaybe(
+					validate(asType(schema), merged, path),
+					continueChain,
+				);
+			} else {
+				downstream = continueChain(current);
 			}
-			return run(i + 1);
+			return downstream;
 		};
 		const handler = handlers[i];
 		if (!handler) return;
 		const result = handler({ type, data: current }, next);
 		return thenMaybe(result, () => {
-			if (!proceeded) return;
+			if (!called) return;
+			return downstream;
 		});
 	};
 	return thenMaybe(run(0), () => current);
@@ -196,7 +212,7 @@ const publishOn = (
 	}
 	const handlers = [...bus.mounted, ...bus.direct];
 	return thenMaybe(validate(asType(schema), data, path), (parsed) =>
-		runHandlers(handlers, type, parsed),
+		runHandlers(handlers, type, parsed, schema, path),
 	);
 };
 

--- a/packages/experimental/src/fn.ts
+++ b/packages/experimental/src/fn.ts
@@ -7,6 +7,17 @@ import {
 	ValidationError,
 } from "./error";
 import {
+	type EventDefination,
+	type EventHandler,
+	type EventOnEntry,
+	isEvent,
+	isEventExtension,
+	isEventOn,
+	mountEvent,
+	mountEventExtension,
+	mountEventOn,
+} from "./event";
+import {
 	type ApplyOns,
 	collectMergeSeeds,
 	collectUsable,
@@ -137,7 +148,9 @@ type WithFns<U> = {
 		? BoundFnCall<U[K]>
 		: U[K] extends VarDefination<any, infer T, any, any>
 			? T
-			: WithFns<U[K]>;
+			: U[K] extends EventDefination<any, any>
+				? never
+				: WithFns<U[K]>;
 };
 
 /** The context `.with` accepts: any var of the fn's WHOLE chain scope
@@ -165,7 +178,9 @@ type StorageLike = {
 type WithFnsSeed<U> = {
 	[K in keyof U as U[K] extends StorageLike
 		? never
-		: K]?: U[K] extends FnDefination<any, any, any, any, any, any>
+		: U[K] extends EventDefination<any, any>
+			? never
+			: K]?: U[K] extends FnDefination<any, any, any, any, any, any>
 		? BoundFnCall<U[K]>
 		: U[K] extends VarDefination<any, infer T, any, any>
 			? T
@@ -467,7 +482,9 @@ export type UseApi<U> = Prettify<
 			? BoundFn<U[K]>
 			: U[K] extends StorageLike
 				? U[K]
-				: UseApi<U[K]>;
+				: U[K] extends EventDefination<any, any>
+					? U[K]
+					: UseApi<U[K]>;
 	} & { [K in UseVarKeys<U>]: UseVarValue<U[K]> }
 >;
 
@@ -489,7 +506,9 @@ type ReadUseApi<U> = Prettify<
 				: `writes "${P[number] & string}" - not callable from a readonly fn`
 			: U[K] extends StorageLike
 				? U[K]
-				: ReadUseApi<U[K]>;
+				: U[K] extends EventDefination<any, any>
+					? U[K]
+					: ReadUseApi<U[K]>;
 	} & { readonly [K in UseVarKeys<U>]: UseVarValue<U[K]> }
 >;
 
@@ -784,6 +803,9 @@ const defineFn = (
 		for (const value of Object.values(mod)) {
 			if (isOn(value) && !own.includes(value)) own.push(value);
 			else if (isVarExtension(value)) ownExts.push(value);
+			else if (isEventOn(value)) mountEventOn(value);
+			else if (isEventExtension(value)) mountEventExtension(value);
+			else if (isEvent(value)) mountEvent(value);
 			else if (isVar(value)) {
 				const schema = (value as { schema?: unknown }).schema;
 				if (schema === undefined || seenVarShadows.has(value)) continue;
@@ -1143,6 +1165,10 @@ const defineFn = (
 							enumerable: true,
 							configurable: true,
 						});
+						continue;
+					}
+					if (isEvent(used)) {
+						target[name] = used;
 						continue;
 					}
 					// Storage mounts whole - do not walk `$models` as a namespace.
@@ -1529,6 +1555,16 @@ export interface InstanceOn<Base, BaseFns, Prefix extends string> {
 			next: () => VarValueOfT<T, Base>,
 		) => VarValueOfT<T, Base>,
 	): OnEntry<T>;
+	/** Event category by reference - never prefixed. */
+	<N extends LiteralString, T extends Record<string, unknown>>(
+		target: EventDefination<N, T>,
+		handler: EventHandler<T>,
+	): EventOnEntry<N, T>;
+	/** Event category by `event.<name>` key - never prefixed. */
+	<N extends LiteralString>(
+		target: `event.${N}`,
+		handler: EventHandler<Record<string, unknown>>,
+	): EventOnEntry<N>;
 	(
 		target: RegExp,
 		handler: (
@@ -1642,10 +1678,12 @@ const builderFn = (baseKey: string, base: Record<string, any>) => {
 				},
 				on: (target: any, a?: any, b?: any) =>
 					(onImpl as any)(
-						// var and scope events live in a global namespace - no prefix.
+						// var, scope, and event categories live in a global
+						// namespace - no builder key prefix.
 						typeof target === "string" &&
 							!target.startsWith("var.") &&
-							!target.startsWith("scope.")
+							!target.startsWith("scope.") &&
+							!target.startsWith("event.")
 							? key + target
 							: target,
 						a,

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -1,3 +1,4 @@
+import { type EventDefination, extendEvent, isEvent, makeEvent } from "./event";
 import { type Fn, fnImpl } from "./fn";
 import { extendVar, on } from "./module";
 
@@ -11,6 +12,29 @@ import {
 	type ValueOfVar,
 	type VarDefination,
 } from "./var";
+
+/** `v.extend`: vars gain fields; events gain kinds. */
+function extend<N extends LiteralString, S, BaseT>(
+	target: VarDefination<N, BaseT, any, any>,
+	schema: S,
+): import("./module").VarExtension<N, S, BaseT>;
+function extend<N extends LiteralString, S>(
+	target: N,
+	schema: S,
+): import("./module").VarExtension<N, S>;
+function extend<
+	N extends LiteralString,
+	T extends Record<string, unknown>,
+	const E extends Record<string, unknown>,
+>(
+	target: EventDefination<N, T>,
+	types: E,
+): import("./event").EventExtension<N, E, T>;
+function extend(target: any, schemaOrTypes: any): any {
+	return isEvent(target)
+		? extendEvent(target, schemaOrTypes)
+		: extendVar(target, schemaOrTypes);
+}
 
 interface V {
 	fn: Fn;
@@ -64,6 +88,18 @@ interface V {
 		NameOfVar<SV>
 	>;
 	/**
+	 * An event CATEGORY: several kinds under one namespace, each with a
+	 * payload schema. Subscribe via `.subscribe` or `v.on`; widen kinds with
+	 * `.extend` / `v.extend`. Same-name declarations across modules merge.
+	 */
+	event: <
+		N extends LiteralString,
+		const T extends Record<string, unknown> = Record<string, never>,
+	>(
+		name: N,
+		types?: T,
+	) => EventDefination<N, T>;
+	/**
 	 * MANY instances of a var, queryable: each named var becomes a
 	 * COLLECTION of rows shaped like its value - `db.user.create(row)`,
 	 * `db.user.findOne({ email })`, findMany/update/delete/count. The
@@ -72,7 +108,7 @@ interface V {
 	 */
 	storage: typeof makeStorage;
 	on: typeof on;
-	extend: typeof extendVar;
+	extend: typeof extend;
 	string: (typeof vTypes)["string"];
 	number: (typeof vTypes)["number"];
 	boolean: (typeof vTypes)["boolean"];
@@ -89,9 +125,10 @@ export const v: V = {
 	record: ((name: string, options: any = {}) =>
 		makeVar(name, { ...options, accessor: true })) as V["record"],
 	derive: deriveVar as V["derive"],
+	event: makeEvent as V["event"],
 	storage: makeStorage,
 	on,
-	extend: extendVar,
+	extend,
 	...vTypes,
 };
 
@@ -103,6 +140,24 @@ export {
 	UnexpectedError,
 	ValidationError,
 } from "./error";
+export type {
+	EventDefination,
+	EventExtension,
+	EventHandler,
+	EventMessage,
+	EventNext,
+	EventOnEntry,
+	EventPayloads,
+	EventsFrom,
+	ModuleEvents,
+} from "./event";
+export {
+	extendEvent,
+	isEvent,
+	isEventExtension,
+	isEventOn,
+	makeEvent,
+} from "./event";
 export type {
 	BoundCall,
 	Context,

--- a/packages/experimental/src/module.ts
+++ b/packages/experimental/src/module.ts
@@ -1,3 +1,12 @@
+import {
+	type EventDefination,
+	type EventHandler,
+	type EventOnEntry,
+	isEvent,
+	isEventExtension,
+	isEventOn,
+	onEvent,
+} from "./event";
 import type { FnDefination } from "./fn";
 import { type InferArgs, type InferInput, isVar, type vTypes } from "./schema";
 import type { WidenSchemaFns } from "./scope";
@@ -91,7 +100,7 @@ export type TargetMatches<N, K extends string> = N extends "*"
 
 /**
  * A module is the unit of composition: a RECORD of members - vars, fns,
- * `on` entries, var extensions - usually just what a file exports
+ * events, `on` entries, extensions - usually just what a file exports
  * (`import * as twoFactor`) or a curated bundle. "Plugin" is not a
  * concept, only a usage: mounting someone else's module. Always an
  * object, never a bare member: `use: [{ createUser }]`, not
@@ -101,6 +110,9 @@ export type TargetMatches<N, K extends string> = N extends "*"
 export type Module = Record<string, unknown> & {
 	$var?: never;
 	$varExtend?: never;
+	$event?: never;
+	$eventExtend?: never;
+	$eventOn?: never;
 	/** Rejects a bare `on` ENTRY (`$on: true`) while letting a storage
 	 * through - its `$on` is the hook-mounting METHOD, not the brand. */
 	$on?: (...args: never[]) => unknown;
@@ -114,6 +126,9 @@ type GroupMember<V> = V extends
 	| { $var: true }
 	| { $on: true }
 	| { $varExtend: true }
+	| { $event: true }
+	| { $eventExtend: true }
+	| { $eventOn: true }
 	| StorageLike
 	| ((...args: any[]) => any)
 	| readonly unknown[]
@@ -170,17 +185,21 @@ type FnEntries<M, D extends number = 3> = {
 		? K
 		: M[K] extends VarDefination<any, any, any, any>
 			? K
-			: M[K] extends StorageLike
+			: M[K] extends EventDefination<any, any>
 				? K
-				: [GroupFns<M[K], GroupDepth[D]>] extends [never]
-					? never
-					: K]: M[K] extends FnDefination<any, any, any, any, any, any>
+				: M[K] extends StorageLike
+					? K
+					: [GroupFns<M[K], GroupDepth[D]>] extends [never]
+						? never
+						: K]: M[K] extends FnDefination<any, any, any, any, any, any>
 		? M[K]
 		: M[K] extends VarDefination<any, any, any, any>
 			? M[K]
-			: M[K] extends StorageLike
+			: M[K] extends EventDefination<any, any>
 				? M[K]
-				: GroupFns<M[K], GroupDepth[D]>;
+				: M[K] extends StorageLike
+					? M[K]
+					: GroupFns<M[K], GroupDepth[D]>;
 };
 
 /** Fns and vars a module exports, keyed by EXPORT name. A plain-record
@@ -204,7 +223,15 @@ export const resolveModules = (
 	modules: readonly Module[],
 ): Record<string, unknown>[] =>
 	modules.map((mod) => {
-		if (isFn(mod) || isVar(mod) || isVarExtension(mod) || isOn(mod)) {
+		if (
+			isFn(mod) ||
+			isVar(mod) ||
+			isVarExtension(mod) ||
+			isOn(mod) ||
+			isEvent(mod) ||
+			isEventExtension(mod) ||
+			isEventOn(mod)
+		) {
 			const bare = mod as { key?: string; name?: string; target?: unknown };
 			const name =
 				bare.key ??
@@ -244,7 +271,16 @@ export const isNamespace = (
 	}
 	const proto = Object.getPrototypeOf(value);
 	if (proto !== Object.prototype && proto !== null) return false;
-	if (isVar(value) || isOn(value) || isVarExtension(value)) return false;
+	if (
+		isVar(value) ||
+		isOn(value) ||
+		isVarExtension(value) ||
+		isEvent(value) ||
+		isEventExtension(value) ||
+		isEventOn(value)
+	) {
+		return false;
+	}
 	// Storage: `$models` + `$adapter` - not a namespace of module members.
 	if (
 		"$models" in value &&
@@ -254,7 +290,14 @@ export const isNamespace = (
 	}
 	return Object.values(value).some(
 		(m) =>
-			isFn(m) || isVar(m) || isOn(m) || isVarExtension(m) || isNamespace(m),
+			isFn(m) ||
+			isVar(m) ||
+			isOn(m) ||
+			isVarExtension(m) ||
+			isEvent(m) ||
+			isEventExtension(m) ||
+			isEventOn(m) ||
+			isNamespace(m),
 	);
 };
 
@@ -289,7 +332,12 @@ export const collectUsable = (
 	const walk = (mod: Record<string, unknown>): Record<string, unknown> => {
 		const out: Record<string, unknown> = {};
 		for (const [name, value] of Object.entries(mod)) {
-			if (isFn(value) || isVar(value) || isStorageValue(value)) {
+			if (
+				isFn(value) ||
+				isVar(value) ||
+				isEvent(value) ||
+				isStorageValue(value)
+			) {
 				out[name] = value;
 			} else if (isNamespace(value)) {
 				const nested = walk(value);
@@ -462,6 +510,16 @@ export function on<T extends "var.get.*" | `var.get.${string}`>(
 	target: T,
 	handler: (c: VarGetContext<VarNameOf<T>>, next: () => unknown) => unknown,
 ): OnEntry<T>;
+/** Subscribe to an event CATEGORY by reference - hears every kind. */
+export function on<N extends LiteralString, T extends Record<string, unknown>>(
+	target: EventDefination<N, T>,
+	handler: EventHandler<T>,
+): EventOnEntry<N, T>;
+/** Subscribe to an event category by `event.<name>` key. */
+export function on<N extends LiteralString>(
+	target: `event.${N}`,
+	handler: EventHandler<Record<string, unknown>>,
+): EventOnEntry<N>;
 export function on<F extends FnDefination<any, any, string, any, any, any>>(
 	target: F,
 	handler: (
@@ -523,6 +581,7 @@ export function on(
 		| string
 		| RegExp
 		| FnDefination<any, any, string, any, any, any>
+		| EventDefination<LiteralString, Record<string, unknown>>
 		| readonly (
 				| string
 				| RegExp
@@ -530,7 +589,15 @@ export function on(
 		  )[],
 	extendOrHandler: any,
 	maybeHandler?: any,
-): OnEntry<string, any> {
+): OnEntry<string, any> | EventOnEntry<string> {
+	// Event categories: by reference or `event.<name>` - distinct handler
+	// shape (`{ type, data }`), collected separately from fn/`var.*` ons.
+	if (
+		isEvent(target) ||
+		(typeof target === "string" && target.startsWith("event."))
+	) {
+		return onEvent(target as never, extendOrHandler);
+	}
 	// A fn reference targets its own key - no string to typo. A LIST
 	// resolves member-wise: one handler, several events.
 	const resolveOne = (member: unknown) =>


### PR DESCRIPTION
Event categories sit alongside vars and fns: a named bus with several payload kinds, subscribe via `.subscribe` or `v.on`, and widen kinds across modules with `.extend` / `v.extend`. Same-name declarations merge for inference (`ModuleEvents`), and mounting a module that exports an event, extension, or event listener registers it when any fn uses that module. Events also land on context so you can `c.signUp.publish(...)` from a handler.